### PR TITLE
Public interface fix

### DIFF
--- a/PelotonEppSdk/Classes/RequestFactory.cs
+++ b/PelotonEppSdk/Classes/RequestFactory.cs
@@ -13,6 +13,14 @@ namespace PelotonEppSdk.Classes
         private readonly LanguageCode _languageCode;
         private readonly Uri _uri;
 
+        /// <summary>
+        /// Creates a RequestFactory with your provided authentication credentials and target URI
+        /// </summary>
+        /// <param name="clientId">Your peloton ClientId - this can be found on MyAccount.</param>
+        /// <param name="clientKey">The password or key used for authentication - this can also be found on MyAccount</param>
+        /// <param name="applicationName">The name of your application. This is used by Peloton for providing support.</param>
+        /// <param name="uri">The target URI for performing transactions - e.g. sbapi.peloton-technologies.com, or api.peloton-technologies.com</param>
+        /// <param name="languageCode">The language you would like responses in.</param>
         public RequestFactory(int clientId, string clientKey, string applicationName, Uri uri, LanguageCode languageCode = LanguageCode.en)
         {
             _clientId = clientId;

--- a/PelotonEppSdk/Interfaces/ICreditCardCreateRequest.cs
+++ b/PelotonEppSdk/Interfaces/ICreditCardCreateRequest.cs
@@ -15,7 +15,7 @@ namespace PelotonEppSdk.Interfaces
         string ExpiryYear { get; set; }
         string CardSecurityCode { get; set; }
 
-        IEnumerable<Reference> References { get; set; }
+        ICollection<Reference> References { get; set; }
 
         string BillingName { get; set; }
         string BillingPhone { get; set; }

--- a/PelotonEppSdk/Interfaces/ICreditCardUpdateRequest.cs
+++ b/PelotonEppSdk/Interfaces/ICreditCardUpdateRequest.cs
@@ -14,7 +14,7 @@ namespace PelotonEppSdk.Interfaces
         string ExpiryMonth { get; set; }
         string ExpiryYear { get; set; }
 
-        IEnumerable<Reference> References { get; set; }
+        ICollection<Reference> References { get; set; }
 
         string BillingName { get; set; }
         string BillingPhone { get; set; }

--- a/PelotonEppSdk/Models/CreditCardRequest.cs
+++ b/PelotonEppSdk/Models/CreditCardRequest.cs
@@ -1,11 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Net;
 using System.Threading.Tasks;
-using System.Web;
 using PelotonEppSdk.Classes;
 using PelotonEppSdk.Enums;
 using PelotonEppSdk.Interfaces;
@@ -14,6 +11,11 @@ namespace PelotonEppSdk.Models
 {
     public class CreditCardRequest : RequestBase, ICreditCardCreateRequest, ICreditCardDeleteRequest, ICreditCardUpdateRequest
     {
+        public CreditCardRequest()
+        {
+            References = new List<Reference>();
+        }
+
         public string CreditCardToken { get; set; }
 
         /// <summary>
@@ -54,7 +56,7 @@ namespace PelotonEppSdk.Models
         /// <summary>
         /// Additional information to record with the credit card request
         /// </summary>
-        public IEnumerable<Reference> References { get; set; }
+        public ICollection<Reference> References { get; set; }
 
         /// <summary>
         /// The primary billing contact name

--- a/PelotonEppSdk/Models/CreditCardTokenTransactionRequest.cs
+++ b/PelotonEppSdk/Models/CreditCardTokenTransactionRequest.cs
@@ -3,16 +3,19 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Net;
 using System.Threading.Tasks;
-using System.Web;
 using PelotonEppSdk.Classes;
 using PelotonEppSdk.Enums;
 
 namespace PelotonEppSdk.Models
 {
-  	public class CreditCardTokenTransactionRequest : RequestBase
+    public class CreditCardTokenTransactionRequest : RequestBase
     {
+  	    public CreditCardTokenTransactionRequest()
+  	    {
+            References = new List<Reference>();
+        }
+
 		/// <summary>
         /// Recommended: Order number provided by the source system, otherwise one will be automatically generated
         /// </summary>

--- a/PelotonEppSdk/Models/FundsTransferRequest.cs
+++ b/PelotonEppSdk/Models/FundsTransferRequest.cs
@@ -25,6 +25,11 @@ namespace PelotonEppSdk.Models
 
     public class FundsTransferRequest : RequestBase
     {
+        public FundsTransferRequest()
+        {
+            References = new List<Reference>();
+        }
+
         /// <summary>
         /// Total Amount to be transferred between accounts. Must be positive.
         ///  </summary>
@@ -67,7 +72,7 @@ namespace PelotonEppSdk.Models
         /// <summary>
         /// A list of fields used to pass additional information to record with the transfer request.
         /// </summary>
-        public IEnumerable<Reference> References { get; set; }
+        public ICollection<Reference> References { get; set; }
 
         public async Task<TransactionResponse> PostAsync()
         {

--- a/PelotonEppSdkTests/StatementsTests.cs
+++ b/PelotonEppSdkTests/StatementsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using PelotonEppSdk.Classes;
 
@@ -18,6 +19,26 @@ namespace PelotonEppSdkTests
             request.ToDate = DateTime.UtcNow;
             var result = request.PostAsync().Result;
             Assert.IsTrue(result.Success);
+        }
+
+        [TestMethod]
+        public void DarrylTest()
+        {
+            try
+            {
+                var requestFactory = new RequestFactory(119, "45bd9dfd", "mychildcarepro™", new Uri("https://testapi.peloton-technologies.com/"));
+                var request = requestFactory.GetStatementsRequest();
+
+                request.AccountToken = "E52A4CF90506099E75C727855812B5A9";
+                request.FromDate = new DateTime(2016, 3, 01);
+                request.ToDate = new DateTime(2016, 4, 1);
+                var result = request.PostAsync().Result;
+            }
+            catch (Exception e)
+            {
+                Debug.Print(e.Message);
+                Assert.Fail();
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes an issue where the public interface used an IEnumerable, where it should have used an ICollection.

IEnumerables are good for return values from functions since they can be converted to any datatype at a low cost, but ICollections are preferred as input values, since it is the most generic structure for storing a list/collection of data.

IEnumerables do not implement Add<T>, which makes them undesirable in this case.
