### PR TITLE
8842 event api support for POST and PUT methods

### DIFF
--- a/PelotonEppSdk/Enums/EventStateEnum.cs
+++ b/PelotonEppSdk/Enums/EventStateEnum.cs
@@ -1,0 +1,13 @@
+﻿namespace PelotonEppSdk.Enums
+{
+    public enum EventStateEnum
+    {
+        Unknown = 0,
+        New = 1,
+        Pending = 2,
+        Active = 3,
+        Inactive = 4,
+        Complete = 5,
+        Cancelled = 6
+    }
+}

--- a/PelotonEppSdk/Models/BankAccount.cs
+++ b/PelotonEppSdk/Models/BankAccount.cs
@@ -14,7 +14,7 @@ namespace PelotonEppSdk.Models
         /// characters or leave blank to use a system generated value. If you are modifying a bank account you must reference the existing
         /// bank_account_token associated with the bank account being modified. A bank_account_token cannot be modified once it has been assigned to a bank account.
         /// </summary>
-        [StringLength(32, ErrorMessage = "The " + nameof(Token) + " field must be less than 32 characters in length.")]
+        [StringLength(32, ErrorMessage = "The " + nameof(Token) + " field must be 32 or fewer characters in length.")]
         public string Token { get; set; }
 
         /// <summary>

--- a/PelotonEppSdk/Models/BankAccount.cs
+++ b/PelotonEppSdk/Models/BankAccount.cs
@@ -14,7 +14,7 @@ namespace PelotonEppSdk.Models
         /// characters or leave blank to use a system generated value. If you are modifying a bank account you must reference the existing
         /// bank_account_token associated with the bank account being modified. A bank_account_token cannot be modified once it has been assigned to a bank account.
         /// </summary>
-        [StringLength(32, ErrorMessage = "The " + nameof(Token) + " field must be less than 32 characters long.")]
+        [StringLength(32, ErrorMessage = "The " + nameof(Token) + " field must be less than 32 characters in length.")]
         public string Token { get; set; }
 
         /// <summary>

--- a/PelotonEppSdk/Models/ClientAuthTokenRequest.cs
+++ b/PelotonEppSdk/Models/ClientAuthTokenRequest.cs
@@ -14,14 +14,14 @@ namespace PelotonEppSdk.Models
         /// <summary>
         /// The Client Authorization Token. Required for POST requests.
         /// </summary>
-        [StringLength(32, MinimumLength = 32, ErrorMessage = "ClientAuthToken must be 32 characters in length")]
+        [StringLength(32, MinimumLength = 32, ErrorMessage = "ClientAuthToken must be 32 characters in length.")]
         public string ClientAuthToken { get; set; }
 
         /// <summary>
         /// The token used to identify the Peloton account
         /// </summary>
         [Required]
-        [StringLength(32, MinimumLength = 32, ErrorMessage = "AccountToken must be 32 characters in length")]
+        [StringLength(32, MinimumLength = 32, ErrorMessage = "AccountToken must be 32 characters in length.")]
         public string AccountToken { get; set; }
 
         /// <summary>

--- a/PelotonEppSdk/Models/Document.cs
+++ b/PelotonEppSdk/Models/Document.cs
@@ -18,13 +18,13 @@ namespace PelotonEppSdk.Models
         /// <summary>
         /// Name that the document has when represented on a file system.
         /// </summary>
-        [Required, StringLength(128, ErrorMessage = "The " + nameof(Filename) + " field must be less than 128 characters long.")]
+        [Required, StringLength(128, ErrorMessage = "The " + nameof(Filename) + " field must be less than 128 characters in length.")]
         public string Filename { get; set; }
 
         /// <summary>
         /// Media Type of the Document. Example http://en.wikipedia.org/wiki/Internet_media_type.
         /// </summary>
-        [Required, StringLength(256, ErrorMessage = "The " + nameof(MediaType) + " field must be less than 256 characters long.")]
+        [Required, StringLength(256, ErrorMessage = "The " + nameof(MediaType) + " field must be less than 256 characters in length.")]
         public string MediaType { get; set; }
     }
 

--- a/PelotonEppSdk/Models/Document.cs
+++ b/PelotonEppSdk/Models/Document.cs
@@ -18,13 +18,13 @@ namespace PelotonEppSdk.Models
         /// <summary>
         /// Name that the document has when represented on a file system.
         /// </summary>
-        [Required, StringLength(128, ErrorMessage = "The " + nameof(Filename) + " field must be less than 128 characters in length.")]
+        [Required, StringLength(128, ErrorMessage = "The " + nameof(Filename) + " field must be 128 or fewer characters in length.")]
         public string Filename { get; set; }
 
         /// <summary>
         /// Media Type of the Document. Example http://en.wikipedia.org/wiki/Internet_media_type.
         /// </summary>
-        [Required, StringLength(256, ErrorMessage = "The " + nameof(MediaType) + " field must be less than 256 characters in length.")]
+        [Required, StringLength(256, ErrorMessage = "The " + nameof(MediaType) + " field must be 256 or fewer characters in length.")]
         public string MediaType { get; set; }
     }
 

--- a/PelotonEppSdk/Models/EventCustomField.cs
+++ b/PelotonEppSdk/Models/EventCustomField.cs
@@ -60,5 +60,21 @@ namespace PelotonEppSdk.Models
                 Required = ei.required
             };
         }
+
+        public static explicit operator event_custom_field(EventCustomField ei)
+        {
+            return new event_custom_field
+            {
+                name = ei.Name,
+                default_value = ei.DefaultValue,
+                type = new type()
+                {
+                    code = ((int)ei.Type).ToString(),
+                    name = ei.Type.ToString()
+                },
+                display_order = ei.DisplayOrder,
+                required = ei.Required
+            };
+        }
     }
 }

--- a/PelotonEppSdk/Models/EventCustomField.cs
+++ b/PelotonEppSdk/Models/EventCustomField.cs
@@ -49,12 +49,12 @@ namespace PelotonEppSdk.Models
         public static explicit operator EventCustomField(event_custom_field ei)
         {
 
-            EventCustomFieldTypeEnum type = 0;
+            EventCustomFieldTypeEnum type = EventCustomFieldTypeEnum.Invalid;
 
             if (ei.type?.code != null)
             {
                 var parseResult = Enum.TryParse(ei.type.code, out type);
-                if (!parseResult) Debug.WriteLine("Failed to parse Client Auth Token response type code.");
+                if (!parseResult) Debug.WriteLine("Failed to parse custom field type code.");
             }
 
             return new EventCustomField

--- a/PelotonEppSdk/Models/EventCustomField.cs
+++ b/PelotonEppSdk/Models/EventCustomField.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using PelotonEppSdk.Enums;
@@ -10,18 +11,23 @@ namespace PelotonEppSdk.Models
         /// <summary>
         /// The name of this custom field.
         /// </summary>
+        [StringLength(50, MinimumLength = 0, ErrorMessage = "Name must be 50 or fewer characters long.")]
         public string Name { get; set; }
         /// <summary>
         /// The default value for this custom field.
         /// </summary>
+        [StringLength(128, MinimumLength = 0, ErrorMessage = "DefaultValue must be 128 or fewer characters long.")]
         public string DefaultValue { get; set; }
         /// <summary>
         /// The type for this custom field.
         /// </summary>
+        //[Required]
         public EventCustomFieldTypeEnum Type { get; set; }
         /// <summary>
         /// The display order for this custom field.
         /// </summary>
+        //[Required]
+        [Range(0, 999, ErrorMessage = "DisplayOrder must be between 0 and 999.")]
         public int DisplayOrder { get; set; }
         /// <summary>
         /// Whether this custom field is required.

--- a/PelotonEppSdk/Models/EventCustomField.cs
+++ b/PelotonEppSdk/Models/EventCustomField.cs
@@ -11,12 +11,12 @@ namespace PelotonEppSdk.Models
         /// <summary>
         /// The name of this custom field.
         /// </summary>
-        [StringLength(50, MinimumLength = 0, ErrorMessage = "Name must be 50 or fewer characters long.")]
+        [StringLength(50, MinimumLength = 0, ErrorMessage = "Name must be 50 or fewer characters in length.")]
         public string Name { get; set; }
         /// <summary>
         /// The default value for this custom field.
         /// </summary>
-        [StringLength(128, MinimumLength = 0, ErrorMessage = "DefaultValue must be 128 or fewer characters long.")]
+        [StringLength(128, MinimumLength = 0, ErrorMessage = "DefaultValue must be 128 or fewer characters in length.")]
         public string DefaultValue { get; set; }
         /// <summary>
         /// The type for this custom field.

--- a/PelotonEppSdk/Models/EventItem.cs
+++ b/PelotonEppSdk/Models/EventItem.cs
@@ -78,6 +78,28 @@ namespace PelotonEppSdk.Models
                     CustomFields = customFields
                 };
             }
+
+            public static explicit operator event_item(EventItem ei)
+            {
+                if (ei == null) return null;
+
+                ICollection<event_custom_field> customFields = null;
+                if (ei.CustomFields != null)
+                    customFields = ei.CustomFields.Select(cf => (event_custom_field)cf).ToList();
+
+                return new event_item
+                {
+                    name = ei.Name,
+                    description = ei.Description,
+                    quantity_selector = ei.QuantitySelector,
+                    default_unit_quantity = ei.DefaultUnitQuantity,
+                    unit_quantity_description = ei.UnitQuantityDescription,
+                    unit_amount = ei.UnitAmount,
+                    amount = ei.Amount,
+                    amount_adjustable = ei.AmountAdjustable,
+                    custom_fields = customFields
+                };
+            }
         }
     }
 }

--- a/PelotonEppSdk/Models/EventItem.cs
+++ b/PelotonEppSdk/Models/EventItem.cs
@@ -65,10 +65,6 @@ namespace PelotonEppSdk.Models
             {
                 if (ei == null) return null;
 
-                ICollection<EventCustomField> customFields = null;
-                if (ei.custom_fields != null)
-                    customFields = ei.custom_fields.Select(cf => (EventCustomField)cf).ToList();
-
                 return new EventItem
                 {
                     Name = ei.name,
@@ -79,17 +75,13 @@ namespace PelotonEppSdk.Models
                     UnitAmount = ei.unit_amount,
                     Amount = ei.amount,
                     AmountAdjustable = ei.amount_adjustable,
-                    CustomFields = customFields
+                    CustomFields = ei.custom_fields?.Select(cf => (EventCustomField)cf).ToList()
                 };
             }
 
             public static explicit operator event_item(EventItem ei)
             {
                 if (ei == null) return null;
-
-                ICollection<event_custom_field> customFields = null;
-                if (ei.CustomFields != null)
-                    customFields = ei.CustomFields.Select(cf => (event_custom_field)cf).ToList();
 
                 return new event_item
                 {
@@ -101,7 +93,7 @@ namespace PelotonEppSdk.Models
                     unit_amount = ei.UnitAmount,
                     amount = ei.Amount,
                     amount_adjustable = ei.AmountAdjustable,
-                    custom_fields = customFields
+                    custom_fields = ei.CustomFields?.Select(cf => (event_custom_field)cf).ToList()
                 };
             }
         }

--- a/PelotonEppSdk/Models/EventItem.cs
+++ b/PelotonEppSdk/Models/EventItem.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
@@ -9,10 +10,12 @@ namespace PelotonEppSdk.Models
         /// <summary>
         /// The name for the event item.
         /// </summary>
+        [StringLength(128, MinimumLength = 0, ErrorMessage = "Name must be 128 or fewer characters long.")]
         public string Name { get; set; }
         /// <summary>
         /// The description for the event item.
         /// </summary>
+        [StringLength(500, MinimumLength = 0, ErrorMessage = "Description must be 500 or fewer characters long.")]
         public string Description { get; set; }
         /// <summary>
         /// Whether quantity selection is allowed for an event item.
@@ -25,6 +28,7 @@ namespace PelotonEppSdk.Models
         /// <summary>
         /// The description for the unit quantity.
         /// </summary>
+        [StringLength(128, MinimumLength = 0, ErrorMessage = "UnitQuantityDescription must be 128 or fewer characters long.")]
         public string UnitQuantityDescription { get; set; }
         /// <summary>
         /// The unit amount for an event item.

--- a/PelotonEppSdk/Models/EventItem.cs
+++ b/PelotonEppSdk/Models/EventItem.cs
@@ -10,12 +10,12 @@ namespace PelotonEppSdk.Models
         /// <summary>
         /// The name for the event item.
         /// </summary>
-        [StringLength(128, MinimumLength = 0, ErrorMessage = "Name must be 128 or fewer characters long.")]
+        [StringLength(128, MinimumLength = 0, ErrorMessage = "Name must be 128 or fewer characters in length.")]
         public string Name { get; set; }
         /// <summary>
         /// The description for the event item.
         /// </summary>
-        [StringLength(500, MinimumLength = 0, ErrorMessage = "Description must be 500 or fewer characters long.")]
+        [StringLength(500, MinimumLength = 0, ErrorMessage = "Description must be 500 or fewer characters in length.")]
         public string Description { get; set; }
         /// <summary>
         /// Whether quantity selection is allowed for an event item.
@@ -28,7 +28,7 @@ namespace PelotonEppSdk.Models
         /// <summary>
         /// The description for the unit quantity.
         /// </summary>
-        [StringLength(128, MinimumLength = 0, ErrorMessage = "UnitQuantityDescription must be 128 or fewer characters long.")]
+        [StringLength(128, MinimumLength = 0, ErrorMessage = "UnitQuantityDescription must be 128 or fewer characters in length.")]
         public string UnitQuantityDescription { get; set; }
         /// <summary>
         /// The unit amount for an event item.

--- a/PelotonEppSdk/Models/EventRequest.cs
+++ b/PelotonEppSdk/Models/EventRequest.cs
@@ -23,20 +23,26 @@ namespace PelotonEppSdk.Models
         [StringLength(32, MinimumLength = 32, ErrorMessage = "AccountToken must be 32 characters long.")]
         public string AccountToken { get; set; }
 
-        //[StringLength(32, MinimumLength = 32, ErrorMessage = "Name must be 32 characters long.")]
+        [StringLength(128, MinimumLength = 0, ErrorMessage = "Name must be 128 or fewer characters long.")]
         public string Name { get; set; }
 
+        //[Required]
+        [StringLength(50, MinimumLength = 0, ErrorMessage = "FriendlyUrlPath must be 50 or fewer characters long.")]
         public string FriendlyUrlPath { get; set; }
 
+        //[Required]
+        [StringLength(500, MinimumLength = 0, ErrorMessage = "Description must be 500 or fewer characters long.")]
         public string Description { get; set; }
 
         //[Required]
         public DateTime? StartDate { get; set; }
 
+        //[Required]
         public DateTime? EndDate { get; set; }
 
         public State State { get; set; }
 
+        //[Required]
         public ICollection<EventItem> Items { get; set; }
 
         public string TermsAndConditionsContent { get; set; }
@@ -77,10 +83,8 @@ namespace PelotonEppSdk.Models
         [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
         internal class event_request : request_base
         {
-            [StringLength(32, MinimumLength = 32)]
             public string event_token { get; set; }
 
-            [StringLength(32, MinimumLength = 32)]
             public string account_token { get; set; }
 
             public string name { get; set; }

--- a/PelotonEppSdk/Models/EventRequest.cs
+++ b/PelotonEppSdk/Models/EventRequest.cs
@@ -35,10 +35,10 @@ namespace PelotonEppSdk.Models
         public string Description { get; set; }
 
         //[Required]
-        public DateTime? StartDate { get; set; }
+        public DateTime? StartDatetime { get; set; }
 
         //[Required]
-        public DateTime? EndDate { get; set; }
+        public DateTime? EndDatetime { get; set; }
 
         public State State { get; set; }
 
@@ -118,8 +118,8 @@ namespace PelotonEppSdk.Models
                     name = eventsRequest.Name,
                     description = eventsRequest.Description,
                     friendly_url_path = eventsRequest.FriendlyUrlPath,
-                    start_date = eventsRequest.StartDate,
-                    end_date = eventsRequest.EndDate,
+                    start_date = eventsRequest.StartDatetime,
+                    end_date = eventsRequest.EndDatetime,
                     state = (state)eventsRequest.State,
                     items = eventsRequest.Items?.Select(ei => (EventItem.event_item)ei).ToList(),
                     terms_and_conditions_content = eventsRequest.TermsAndConditionsContent,

--- a/PelotonEppSdk/Models/EventRequest.cs
+++ b/PelotonEppSdk/Models/EventRequest.cs
@@ -13,25 +13,25 @@ namespace PelotonEppSdk.Models
 {
     public class EventRequest : RequestBase
     {
-        [StringLength(32, MinimumLength = 32, ErrorMessage = nameof(EventToken) + " must be 32 characters long.")]
+        [StringLength(32, MinimumLength = 32, ErrorMessage = nameof(EventToken) + " must be 32 characters in length.")]
         public string EventToken { get; set; }
 
         /// <summary>
         /// ClientToken for the target peloton account
         /// </summary>
         //[Required]
-        [StringLength(32, MinimumLength = 32, ErrorMessage = "AccountToken must be 32 characters long.")]
+        [StringLength(32, MinimumLength = 32, ErrorMessage = "AccountToken must be 32 characters in length.")]
         public string AccountToken { get; set; }
 
-        [StringLength(128, MinimumLength = 0, ErrorMessage = "Name must be 128 or fewer characters long.")]
+        [StringLength(128, MinimumLength = 0, ErrorMessage = "Name must be 128 or fewer characters in length.")]
         public string Name { get; set; }
 
         //[Required]
-        [StringLength(50, MinimumLength = 0, ErrorMessage = "FriendlyUrlPath must be 50 or fewer characters long.")]
+        [StringLength(50, MinimumLength = 0, ErrorMessage = "FriendlyUrlPath must be 50 or fewer characters in length.")]
         public string FriendlyUrlPath { get; set; }
 
         //[Required]
-        [StringLength(500, MinimumLength = 0, ErrorMessage = "Description must be 500 or fewer characters long.")]
+        [StringLength(500, MinimumLength = 0, ErrorMessage = "Description must be 500 or fewer characters in length.")]
         public string Description { get; set; }
 
         //[Required]

--- a/PelotonEppSdk/Models/EventRequest.cs
+++ b/PelotonEppSdk/Models/EventRequest.cs
@@ -2,7 +2,10 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
+using System.Web;
 using PelotonEppSdk.Classes;
 using PelotonEppSdk.Enums;
 
@@ -10,19 +13,27 @@ namespace PelotonEppSdk.Models
 {
     public class EventRequest : RequestBase
     {
-        [Required]
         [StringLength(32, MinimumLength = 32, ErrorMessage = nameof(EventToken) + " must be 32 characters long.")]
         public string EventToken { get; set; }
 
+        /// <summary>
+        /// ClientToken for the target peloton account
+        /// </summary>
+        //[Required]
+        [StringLength(32, MinimumLength = 32, ErrorMessage = "AccountToken must be 32 characters long.")]
+        public string AccountToken { get; set; }
+
+        //[StringLength(32, MinimumLength = 32, ErrorMessage = "Name must be 32 characters long.")]
         public string Name { get; set; }
 
         public string FriendlyUrlPath { get; set; }
 
         public string Description { get; set; }
 
-        public DateTime StartDatetime { get; set; }
+        //[Required]
+        public DateTime? StartDate { get; set; }
 
-        public DateTime EndDatetime { get; set; }
+        public DateTime? EndDate { get; set; }
 
         public State State { get; set; }
 
@@ -32,35 +43,45 @@ namespace PelotonEppSdk.Models
 
         public string RefundPolicyContent { get; set; }
 
+        /// <exception cref="HttpException"><see cref="HttpStatusCode"/> is not <c>2XX Success</c>.</exception>
         public async Task<EventResponse> GetAsync()
         {
             var client = new PelotonClient();
             var parameter = "?token=" + EventToken;
             parameter += "&languageCode=" + LanguageCode;
-            var result =
-                await
-                    client.GetAsync<event_response>((event_request) this, ApiTarget.Events, parameter)
-                        .ConfigureAwait(false);
+            var result = await client.GetAsync<event_response>((event_request) this, ApiTarget.Events, parameter).ConfigureAwait(false);
             return (EventResponse)result;
         }
 
-        ///// <exception cref="HttpException"><see cref="HttpStatusCode"/> is not <c>2XX Success</c>.</exception>
-        //public async Task<EventResponse> PostAsync()
-        //{
-        //    var client = new PelotonClient();
-        //    var request = (event_request)this;
-        //    var result = await client.PostAsync<event_response>(request, ApiTarget.Events, EventToken).ConfigureAwait(false);
-        //    return (EventResponse)result;
-        //}
+        /// <exception cref="HttpException"><see cref="HttpStatusCode"/> is not <c>2XX Success</c>.</exception>
+        public async Task<EventResponse> PostAsync()
+        {
+            var client = new PelotonClient();
+            var request = (event_request)this;
+            var result = await client.PostAsync<event_response>(request, ApiTarget.Events, null).ConfigureAwait(false);
+            return (EventResponse)result;
+        }
+
+        /// <exception cref="HttpException"><see cref="HttpStatusCode"/> is not <c>2XX Success</c>.</exception>
+        public async Task<EventResponse> PutAsync()
+        {
+            var client = new PelotonClient();
+            var parameter = "?token=" + EventToken;
+            var request = (event_request)this;
+            var result = await client.PutAsync<event_response>(request, ApiTarget.Events, parameter).ConfigureAwait(false);
+            return (EventResponse)result;
+        }
 
         [SuppressMessage("ReSharper", "InconsistentNaming")]
         [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
         [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
         internal class event_request : request_base
         {
-            [Required]
             [StringLength(32, MinimumLength = 32)]
             public string event_token { get; set; }
+
+            [StringLength(32, MinimumLength = 32)]
+            public string account_token { get; set; }
 
             public string name { get; set; }
 
@@ -68,9 +89,9 @@ namespace PelotonEppSdk.Models
 
             public string description { get; set; }
 
-            public DateTime start_datetime { get; set; }
+            public DateTime? start_date { get; set; }
 
-            public DateTime end_datetime { get; set; }
+            public DateTime? end_date { get; set; }
 
             public state state { get; set; }
 
@@ -87,14 +108,16 @@ namespace PelotonEppSdk.Models
                 return new event_request(eventsRequest)
                 {
                     event_token = eventsRequest.EventToken,
+                    account_token = eventsRequest.AccountToken,
                     application_name = eventsRequest.ApplicationName,
                     authentication_header = eventsRequest.AuthenticationHeader,
                     name = eventsRequest.Name,
                     description = eventsRequest.Description,
                     friendly_url_path = eventsRequest.FriendlyUrlPath,
-                    start_datetime = eventsRequest.StartDatetime,
-                    end_datetime = eventsRequest.EndDatetime,
-                    //state = eventsRequest.State,
+                    start_date = eventsRequest.StartDate,
+                    end_date = eventsRequest.EndDate,
+                    state = (state)eventsRequest.State,
+                    items = eventsRequest.Items?.Select(ei => (EventItem.event_item)ei).ToList(),
                     terms_and_conditions_content = eventsRequest.TermsAndConditionsContent,
                     refund_policy_content = eventsRequest.RefundPolicyContent,
                     language_code = Enum.GetName(typeof(LanguageCode), eventsRequest.LanguageCode)

--- a/PelotonEppSdk/Models/EventResponse.cs
+++ b/PelotonEppSdk/Models/EventResponse.cs
@@ -26,11 +26,11 @@ namespace PelotonEppSdk.Models
         /// <summary>
         /// The start datetime for the event.
         /// </summary>
-        public DateTime StartDate { get; set; }
+        public DateTime StartDatetime { get; set; }
         /// <summary>
         ///  The end datetime for the event.
         /// </summary>
-        public DateTime EndDate { get; set; }
+        public DateTime EndDatetime { get; set; }
         /// <summary>
         /// The state of the event.
         /// </summary>
@@ -86,8 +86,8 @@ namespace PelotonEppSdk.Models
                 Name = eventResponse.name,
                 FriendlyUrlPath = eventResponse.friendly_url_path,
                 Description = eventResponse.description,
-                StartDate = eventResponse.start_date,
-                EndDate = eventResponse.end_date,
+                StartDatetime = eventResponse.start_date,
+                EndDatetime = eventResponse.end_date,
                 State = eventStateEnumValue,
                 Items = eventResponse.items?.Select(ei => (EventItem)ei).ToList(),
                 TermsAndConditionsContent = eventResponse.terms_and_conditions_content,

--- a/PelotonEppSdk/Models/EventResponse.cs
+++ b/PelotonEppSdk/Models/EventResponse.cs
@@ -74,10 +74,6 @@ namespace PelotonEppSdk.Models
         {
             if (eventResponse == null) return null;
 
-            ICollection<EventItem> items = null;
-            if (eventResponse.items != null)
-                items = eventResponse.items.Select(ei => (EventItem)ei).ToList();
-
             var eventState = (State)eventResponse.state;
             EventStateEnum eventStateEnumValue = EventStateEnum.Unknown;
             if (eventState != null)
@@ -93,7 +89,7 @@ namespace PelotonEppSdk.Models
                 StartDate = eventResponse.start_date,
                 EndDate = eventResponse.end_date,
                 State = eventStateEnumValue,
-                Items = items,
+                Items = eventResponse.items?.Select(ei => (EventItem)ei).ToList(),
                 TermsAndConditionsContent = eventResponse.terms_and_conditions_content,
                 RefundPolicyContent = eventResponse.refund_policy_content,
                 EventToken = eventResponse.event_token,

--- a/PelotonEppSdk/Models/EventResponse.cs
+++ b/PelotonEppSdk/Models/EventResponse.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using PelotonEppSdk.Enums;
 
 namespace PelotonEppSdk.Models
 {
@@ -17,6 +17,8 @@ namespace PelotonEppSdk.Models
         /// The name for the event.
         /// </summary>
         public string Name { get; set; }
+
+        public string FriendlyUrlPath { get; set; }
         /// <summary>
         /// The description for the event.
         /// </summary>
@@ -24,15 +26,15 @@ namespace PelotonEppSdk.Models
         /// <summary>
         /// The start datetime for the event.
         /// </summary>
-        public DateTime StartDatetime { get; set; }
+        public DateTime StartDate { get; set; }
         /// <summary>
         ///  The end datetime for the event.
         /// </summary>
-        public DateTime EndDatetime { get; set; }
+        public DateTime EndDate { get; set; }
         /// <summary>
         /// The state of the event.
         /// </summary>
-        public State State { get; set; }
+        public EventStateEnum State { get; set; }
         /// <summary>
         /// The list of items associated with an event.
         /// </summary>
@@ -59,9 +61,10 @@ namespace PelotonEppSdk.Models
     {
         public string event_token { get; set; }
         public string name { get; set; }
+        public string friendly_url_path { get; set; }
         public string description { get; set; }
-        public DateTime start_datetime { get; set; }
-        public DateTime end_datetime { get; set; }
+        public DateTime start_date { get; set; }
+        public DateTime end_date { get; set; }
         public state state { get; set; }
         public ICollection<EventItem.event_item> items { get; set; }
         public string terms_and_conditions_content { get; set; }
@@ -75,13 +78,21 @@ namespace PelotonEppSdk.Models
             if (eventResponse.items != null)
                 items = eventResponse.items.Select(ei => (EventItem)ei).ToList();
 
+            var eventState = (State)eventResponse.state;
+            EventStateEnum eventStateEnumValue = EventStateEnum.Unknown;
+            if (eventState != null)
+            {
+                eventStateEnumValue = (EventStateEnum)int.Parse(eventState.Code);
+            }
+
             return new EventResponse(eventResponse)
             {
                 Name = eventResponse.name,
+                FriendlyUrlPath = eventResponse.friendly_url_path,
                 Description = eventResponse.description,
-                StartDatetime = eventResponse.start_datetime,
-                EndDatetime = eventResponse.end_datetime,
-                State = (State)eventResponse.state,
+                StartDate = eventResponse.start_date,
+                EndDate = eventResponse.end_date,
+                State = eventStateEnumValue,
                 Items = items,
                 TermsAndConditionsContent = eventResponse.terms_and_conditions_content,
                 RefundPolicyContent = eventResponse.refund_policy_content,

--- a/PelotonEppSdk/Models/FundsTransferRequest.cs
+++ b/PelotonEppSdk/Models/FundsTransferRequest.cs
@@ -47,14 +47,14 @@ namespace PelotonEppSdk.Models
         /// The account identifier used to identify a bank account.
         /// </summary>
         [Required]
-        [StringLength(32, MinimumLength = 32, ErrorMessage = "BankAccountToken must be 32 characters long.")]
+        [StringLength(32, MinimumLength = 32, ErrorMessage = "BankAccountToken must be 32 characters in length.")]
         public string BankAccountToken { get; set; }
 
         /// <summary>
         /// ClientToken for the target peloton account
         /// </summary>
         [Required]
-        [StringLength(32, MinimumLength = 32, ErrorMessage = "AccountToken must be 32 characters long.")]
+        [StringLength(32, MinimumLength = 32, ErrorMessage = "AccountToken must be 32 characters in length.")]
         public string AccountToken { get; set; }
 
         /// <summary>

--- a/PelotonEppSdk/Models/StatementsRequest.cs
+++ b/PelotonEppSdk/Models/StatementsRequest.cs
@@ -16,7 +16,7 @@ namespace PelotonEppSdk.Models
         /// The Account token for the account which the statement is being created for
         /// </summary>
         [Required]
-        [StringLength(32, MinimumLength = 32, ErrorMessage = "AccountToken must be 32 characters in length")]
+        [StringLength(32, MinimumLength = 32, ErrorMessage = "AccountToken must be 32 characters in length.")]
         public string AccountToken { get; set; }
 
         /// <summary>

--- a/PelotonEppSdk/Models/TransferRequest.cs
+++ b/PelotonEppSdk/Models/TransferRequest.cs
@@ -15,11 +15,11 @@ namespace PelotonEppSdk.Models
     public class TransferRequest : RequestBase
     {
         [Required]
-        [StringLength(32, ErrorMessage = "SourceAccountToken must be 32 characters long.", MinimumLength = 32)]
+        [StringLength(32, ErrorMessage = "SourceAccountToken must be 32 characters in length.", MinimumLength = 32)]
         public string SourceAccountToken { get; set; }
 
         [Required]
-        [StringLength(32,ErrorMessage = "TargetAccountToken must be 32 characters long.", MinimumLength = 32)]
+        [StringLength(32,ErrorMessage = "TargetAccountToken must be 32 characters in length.", MinimumLength = 32)]
         public string TargetAccountToken { get; set; }
 
         [Range(0.01,int.MaxValue)]

--- a/PelotonEppSdk/PelotonEppSdk.csproj
+++ b/PelotonEppSdk/PelotonEppSdk.csproj
@@ -47,6 +47,7 @@
     <Compile Include="Enums\ClientAuthTokenAuthorizationType.cs" />
     <Compile Include="Enums\CreditCardType.cs" />
     <Compile Include="Enums\EventCustomFieldTypeEnum.cs" />
+    <Compile Include="Enums\EventStateEnum.cs" />
     <Compile Include="Enums\TransactionType.cs" />
     <Compile Include="Interfaces\IBankAccountCreateRequest.cs" />
     <Compile Include="Interfaces\IBankAccountDeleteRequest.cs" />

--- a/PelotonEppSdk/Properties/AssemblyInfo.cs
+++ b/PelotonEppSdk/Properties/AssemblyInfo.cs
@@ -34,3 +34,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.1.1")]
 [assembly: AssemblyFileVersion("1.0.1.1")]
+
+[assembly: InternalsVisibleTo("PelotonEppSdkTests")]

--- a/PelotonEppSdkTests/ClientAuthTokenTests.cs
+++ b/PelotonEppSdkTests/ClientAuthTokenTests.cs
@@ -56,7 +56,7 @@ namespace PelotonEppSdkTests
                 }
             }
 
-            Assert.AreEqual("AccountToken must be 32 characters in length", errors.Single());
+            Assert.AreEqual("AccountToken must be 32 characters in length.", errors.Single());
         }
 
         [TestMethod]

--- a/PelotonEppSdkTests/EventCreateTests.cs
+++ b/PelotonEppSdkTests/EventCreateTests.cs
@@ -2,78 +2,557 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using PelotonEppSdk.Classes;
+using PelotonEppSdk.Enums;
 using PelotonEppSdk.Models;
 
 namespace PelotonEppSdkTests
 {
     [TestClass]
-    public class EventCreateTests : TestBase
+    public class EventCreateTests : EventTestsBase
     {
-        //private string duplicateFriendlyUrlPath = "NEWEVENT";
+        private static string duplicateFriendlyUrlPath = "NEWEVENT";
 
-        //private static EventRequest GetBasicEventRequest()
-        //{
-        //    var factory = new RequestFactory(24, "Password123", "PelonEppSdkTests", baseUri);
-        //    var request = factory.GetEventCreateRequest();
-        //    return request;
-        //}
+        private static EventRequest GetBasicEventRequest()
+        {
+            var factory = new RequestFactory(24, "Password123", "PelonEppSdkTests", baseUri);
+            var request = factory.GetEventRequest();
+            request.AccountToken = "0C01957EE5D8B468342E673CC010BE0A";
+            request.Name = "Test";
+            request.Description = "Test";
+            request.FriendlyUrlPath = duplicateFriendlyUrlPath + Guid.NewGuid().ToString("N");
+            request.Items = new List<EventItem>()
+            {
+                new EventItem
+                {
+                    Amount = 1,
+                    AmountAdjustable = true,
+                    CustomFields = new List<EventCustomField>
+                    {
+                        new EventCustomField
+                        {
+                            DefaultValue = "default value",
+                            DisplayOrder = 0,
+                            Name = "custom field name",
+                            Required = true,
+                            Type = EventCustomFieldTypeEnum.@string
+                        }
+                    },
+                    DefaultUnitQuantity = 1,
+                    Description = "event item description",
+                    Name = "event item 1",
+                    QuantitySelector = true,
+                    UnitAmount = 1,
+                    UnitQuantityDescription = "description for quantity"
+                }
+            };
+            request.StartDate = DateTime.UtcNow;
+            request.EndDate = DateTime.UtcNow.AddDays(1);
+            request.TermsAndConditionsContent = "";
+            request.RefundPolicyContent = "";
+            return request;
+        }
+        
+        private static EventRequest GetBasicEventRequest(string token, LanguageCode languageCode = LanguageCode.en)
+        {
+            var factory = new RequestFactory(24, "PAssword123", "PelonEppSdkTests", baseUri, languageCode);
+            var request = factory.GetEventRequest();
+            request.EventToken = token;
+            return request;
+        }
 
-        //[TestMethod]
-        //public void TestSuccessCreateEvent()
-        //{
-        //    var createRequest = GetBasicEventRequest();
-        //    createRequest.Name = "Test";
-        //    createRequest.Description = "Test";
-        //    createRequest.FriendlyUrlPath = duplicateFriendlyUrlPath;
-        //    createRequest.StartDatetime = DateTime.UtcNow;
-        //    createRequest.EndDatetime = DateTime.UtcNow;
-        //    createRequest.TermsAndConditionsContent = "";
-        //    createRequest.RefundPolicyContent = "";
+        [TestMethod]
+        public void TestCreateEventSuccess()
+        {
+            var createRequest = GetBasicEventRequest();
 
-        //    var errors = new Collection<string>();
-        //    if (!createRequest.TryValidate(errors))
-        //    {
-        //        foreach (var error in errors)
-        //        {
-        //            Debug.WriteLine(error);
-        //        }
-        //    }
+            var errors = new Collection<string>();
+            if (!createRequest.TryValidate(errors))
+            {
+                foreach (var error in errors)
+                {
+                    Debug.WriteLine(error);
+                }
+            }
 
-        //    var result = createRequest.PostAsync().Result;
-        //    Debug.WriteLine(result.Message);
-        //    Debug.WriteLineIf((result.Errors != null && result.Errors.Count >= 1), string.Join("; ", result.Errors ?? new List<string>()));
-        //    Assert.IsTrue(result.Success);
-        //    Assert.AreEqual(0, result.MessageCode);
-        //}
+            var result = createRequest.PostAsync().Result;
+            Debug.WriteLine(result.Message);
+            Debug.WriteLineIf((result.Errors != null && result.Errors.Count >= 1), string.Join("; ", result.Errors ?? new List<string>()));
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual(0, result.MessageCode);
+            Assert.AreEqual(32, result.EventToken.Length);
+            
+            
+            // get and check the event
+            var getRequest = GetBasicEventRequest(result.EventToken);
+            var getResult = getRequest.GetAsync().Result;
+            Debug.WriteLine(getResult.Message);
+            Debug.WriteLineIf((getResult.Errors != null && getResult.Errors.Count >= 1), string.Join("; ", getResult.Errors ?? new List<string>()));
+            Assert.IsTrue(getResult.Success);
+            Assert.AreEqual(0, getResult.MessageCode);
 
-        //[TestMethod]
-        //public void TestFailureCreateDuplicateEvent()
-        //{
-        //    var createRequest = GetBasicEventRequest();
-        //    createRequest.Name = "Test";
-        //    createRequest.Description = "Test";
-        //    createRequest.FriendlyUrlPath = duplicateFriendlyUrlPath; 
-        //    createRequest.StartDatetime = DateTime.UtcNow;
-        //    createRequest.EndDatetime = DateTime.UtcNow;
-        //    createRequest.TermsAndConditionsContent = "";
-        //    createRequest.RefundPolicyContent = "";
+            CheckResponseAndResult(createRequest, getResult, EventStateEnum.New);
+        }
 
-        //    var errors = new Collection<string>();
-        //    if (!createRequest.TryValidate(errors))
-        //    {
-        //        foreach (var error in errors)
-        //        {
-        //            Debug.WriteLine(error);
-        //        }
-        //    }
+        [TestMethod]
+        public void TestCreateEventWithMultipleItems()
+        {
+            var createRequest = GetBasicEventRequest();
 
-        //    var result = createRequest.PostAsync().Result;
-        //    Debug.WriteLine(result.Message);
-        //    Debug.WriteLineIf((result.Errors != null && result.Errors.Count >= 1), string.Join("; ", result.Errors ?? new List<string>()));
-        //    Assert.IsFalse(result.Success);
-        //    Assert.AreEqual(106, result.MessageCode);
-        //}
+            createRequest.Items = new List<EventItem>()
+            {
+                new EventItem
+                {
+                    Amount = 1,
+                    AmountAdjustable = true,
+                    CustomFields = new List<EventCustomField>
+                    {
+                        new EventCustomField
+                        {
+                            DefaultValue = "default value",
+                            DisplayOrder = 0,
+                            Name = "custom field name",
+                            Required = true,
+                            Type = EventCustomFieldTypeEnum.@string
+                        }
+                    },
+                    DefaultUnitQuantity = 10,
+                    Description = "event item description",
+                    Name = "event item 1",
+                    QuantitySelector = true,
+                    UnitAmount = 1,
+                    UnitQuantityDescription = "description for quantity"
+                },
+                new EventItem
+                {
+                    Amount = 2,
+                    AmountAdjustable = false,
+                    CustomFields = new List<EventCustomField>
+                    {
+                        new EventCustomField
+                        {
+                            DefaultValue = "item 2 custom field default value",
+                            DisplayOrder = 0,
+                            Name = "item 2 custom field name",
+                            Required = true,
+                            Type = EventCustomFieldTypeEnum.@string
+                        }
+                    },
+                    DefaultUnitQuantity = 10,
+                    Description = "event item 2 description",
+                    Name = "event item 2",
+                    QuantitySelector = true,
+                    UnitAmount = 25,
+                    UnitQuantityDescription = "description for quantity 25"
+                },
+                new EventItem
+                {
+                    Amount = 3,
+                    AmountAdjustable = true,
+                    CustomFields = new List<EventCustomField>
+                    {
+                        new EventCustomField
+                        {
+                            DefaultValue = "item 3 custom field default value",
+                            DisplayOrder = 0,
+                            Name = "item 3 custom field name",
+                            Required = true,
+                            Type = EventCustomFieldTypeEnum.@string
+                        }
+                    },
+                    DefaultUnitQuantity = 10,
+                    Description = "event item 3 description",
+                    Name = "event item 3",
+                    QuantitySelector = true,
+                    UnitAmount = 50,
+                    UnitQuantityDescription = "description for quantity 50"
+                }
+            };
+
+            var errors = new Collection<string>();
+            if (!createRequest.TryValidate(errors))
+            {
+                foreach (var error in errors)
+                {
+                    Debug.WriteLine(error);
+                }
+            }
+
+            var result = createRequest.PostAsync().Result;
+            Debug.WriteLine(result.Message);
+            Debug.WriteLineIf((result.Errors != null && result.Errors.Count >= 1), string.Join("; ", result.Errors ?? new List<string>()));
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual(0, result.MessageCode);
+            Assert.AreEqual(32, result.EventToken.Length);
+
+
+            // get and check the event
+            var getRequest = GetBasicEventRequest(result.EventToken);
+            var getResult = getRequest.GetAsync().Result;
+            Debug.WriteLine(getResult.Message);
+            Debug.WriteLineIf((getResult.Errors != null && getResult.Errors.Count >= 1), string.Join("; ", getResult.Errors ?? new List<string>()));
+            Assert.IsTrue(getResult.Success);
+            Assert.AreEqual(0, getResult.MessageCode);
+
+            CheckResponseAndResult(createRequest, getResult, EventStateEnum.New);
+        }
+
+        [TestMethod]
+        public void TestCreateEventWithMultipleCustomFields()
+        {
+            var createRequest = GetBasicEventRequest();
+
+            createRequest.Items = new List<EventItem>()
+            {
+                new EventItem
+                {
+                    Amount = 1,
+                    AmountAdjustable = true,
+                    CustomFields = new List<EventCustomField>
+                    {
+                        new EventCustomField
+                        {
+                            DefaultValue = "default value 1",
+                            DisplayOrder = 5,
+                            Name = "custom field name 1",
+                            Required = true,
+                            Type = EventCustomFieldTypeEnum.@string
+                        },
+                        new EventCustomField
+                        {
+                            DefaultValue = "default value 2",
+                            DisplayOrder = 10,
+                            Name = "custom field name 2",
+                            Required = true,
+                            Type = EventCustomFieldTypeEnum.@string
+                        },
+                        new EventCustomField
+                        {
+                            DefaultValue = "default value 3",
+                            DisplayOrder = 15,
+                            Name = "custom field name 3",
+                            Required = false,
+                            Type = EventCustomFieldTypeEnum.@string
+                        },
+                        new EventCustomField
+                        {
+                            DefaultValue = "default value 4",
+                            DisplayOrder = 20,
+                            Name = "custom field name 4",
+                            Required = false,
+                            Type = EventCustomFieldTypeEnum.@string
+                        }
+                    },
+                    DefaultUnitQuantity = 10,
+                    Description = "event item description",
+                    Name = "event item 1",
+                    QuantitySelector = true,
+                    UnitAmount = 1,
+                    UnitQuantityDescription = "description for quantity"
+                }
+            };
+
+            var errors = new Collection<string>();
+            if (!createRequest.TryValidate(errors))
+            {
+                foreach (var error in errors)
+                {
+                    Debug.WriteLine(error);
+                }
+            }
+
+            var result = createRequest.PostAsync().Result;
+            Debug.WriteLine(result.Message);
+            Debug.WriteLineIf((result.Errors != null && result.Errors.Count >= 1), string.Join("; ", result.Errors ?? new List<string>()));
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual(0, result.MessageCode);
+            Assert.AreEqual(32, result.EventToken.Length);
+
+
+            // get and check the event
+            var getRequest = GetBasicEventRequest(result.EventToken);
+            var getResult = getRequest.GetAsync().Result;
+            Debug.WriteLine(getResult.Message);
+            Debug.WriteLineIf((getResult.Errors != null && getResult.Errors.Count >= 1), string.Join("; ", getResult.Errors ?? new List<string>()));
+            Assert.IsTrue(getResult.Success);
+            Assert.AreEqual(0, getResult.MessageCode);
+
+            CheckResponseAndResult(createRequest, getResult, EventStateEnum.New);
+        }
+
+        [TestMethod]
+        public void TestCreateEventDuplicateEvent()
+        {
+            var createRequest = GetBasicEventRequest();
+            createRequest.Name = "Test";
+            createRequest.Description = "Test";
+            createRequest.FriendlyUrlPath = duplicateFriendlyUrlPath;
+            createRequest.Items = new List<EventItem>()
+            {
+                new EventItem
+                {
+                    Description = "event item description",
+                    Name = "event item 1",
+                }
+            };
+            createRequest.StartDate = DateTime.UtcNow;
+            createRequest.EndDate = DateTime.UtcNow;
+            createRequest.TermsAndConditionsContent = "";
+            createRequest.RefundPolicyContent = "";
+
+            var errors = new Collection<string>();
+            if (!createRequest.TryValidate(errors))
+            {
+                foreach (var error in errors)
+                {
+                    Debug.WriteLine(error);
+                }
+            }
+
+            var result = createRequest.PostAsync().Result;
+            Debug.WriteLine(result.Message);
+            Debug.WriteLineIf((result.Errors != null && result.Errors.Count >= 1), string.Join("; ", result.Errors ?? new List<string>()));
+            Assert.IsFalse(result.Success);
+            Assert.AreEqual(1, result.MessageCode);
+            Assert.AreEqual("Validation Error", result.Message);
+            Assert.AreEqual("friendly_url_path: must be unique", result.Errors.Single());
+        }
+
+        [TestMethod]
+        public void TestCreateEventValidationErrors()
+        {
+            var factory = new RequestFactory(24, "Password123", "PelonEppSdkTests", baseUri);
+            var request = factory.GetEventRequest();
+            //var createRequest = GetBasicEventRequest();
+
+            var errors = new Collection<string>();
+            if (!request.TryValidate(errors))
+            {
+                foreach (var error in errors)
+                {
+                    Debug.WriteLine(error);
+                }
+            }
+
+            Assert.AreEqual(7, errors.Count);
+
+        }
+
+        [TestMethod]
+        public void TestCreateEventValidationErrors2()
+        {
+            var factory = new RequestFactory(24, "Password123", "PelonEppSdkTests", baseUri);
+            var request = factory.GetEventRequest();
+            request.Name = new string('a', 40);
+
+
+            var create = request;
+            var update = request;
+
+            var createErrors = new Collection<string>();
+            if (!create.TryValidate(createErrors))
+            {
+                foreach (var error in createErrors)
+                {
+                    Debug.WriteLine(error);
+                }
+            }
+
+            var updateErrors = new Collection<string>();
+            if (!update.TryValidate(updateErrors))
+            {
+                foreach (var error in updateErrors)
+                {
+                    Debug.WriteLine(error);
+                }
+            }
+
+            Assert.AreEqual(1, updateErrors.Count);
+            Assert.AreEqual(1, createErrors.Count);
+
+        }
+
+        [TestMethod]
+        public void TestUpdateEventSuccess()
+        {
+            var createRequest = GetBasicEventRequest();
+
+            var errors = new Collection<string>();
+            if (!createRequest.TryValidate(errors))
+            {
+                foreach (var error in errors)
+                {
+                    Debug.WriteLine(error);
+                }
+            }
+
+            var result = createRequest.PostAsync().Result;
+            Debug.WriteLine(result.Message);
+            Debug.WriteLineIf((result.Errors != null && result.Errors.Count >= 1), string.Join("; ", result.Errors ?? new List<string>()));
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual(0, result.MessageCode);
+            Assert.AreEqual(32, result.EventToken.Length);
+
+
+            // get and check the event
+            var getRequest = GetBasicEventRequest(result.EventToken);
+            var getResult = getRequest.GetAsync().Result;
+            Debug.WriteLine(getResult.Message);
+            Debug.WriteLineIf((getResult.Errors != null && getResult.Errors.Count >= 1), string.Join("; ", getResult.Errors ?? new List<string>()));
+            Assert.IsTrue(getResult.Success);
+            Assert.AreEqual(0, getResult.MessageCode);
+
+            CheckResponseAndResult(createRequest, getResult, EventStateEnum.New);
+
+
+            // update the createRequest
+            var updateRequest = createRequest;
+            updateRequest.EventToken = result.EventToken;
+            updateRequest.Name = updateRequest.Name + " Updated";
+
+            updateRequest.State = new State()
+            {
+                Code = EventStateEnum.Active.ToString(),
+                Name = EventStateEnum.Active.ToString()
+            };
+            updateRequest.Items.First().Amount = 10;
+            updateRequest.Items.First().UnitAmount = 5;
+            updateRequest.Items.First().CustomFields.Add(
+                new EventCustomField
+                {
+                    DefaultValue = "default value 2",
+                    DisplayOrder = 10,
+                    Name = "custom field name 2",
+                    Required = true,
+                    Type = EventCustomFieldTypeEnum.@string
+                });
+            updateRequest.Items.First().CustomFields.Add(
+                new EventCustomField
+                {
+                    DefaultValue = "default value 3",
+                    DisplayOrder = 15,
+                    Name = "custom field name 3",
+                    Required = false,
+                    Type = EventCustomFieldTypeEnum.@string
+                });
+
+            errors = new Collection<string>();
+            if (!updateRequest.TryValidate(errors))
+            {
+                foreach (var error in errors)
+                {
+                    Debug.WriteLine(error);
+                }
+            }
+
+            result = updateRequest.PutAsync().Result;
+            Debug.WriteLine(result.Message);
+            Debug.WriteLineIf((result.Errors != null && result.Errors.Count >= 1), string.Join("; ", result.Errors ?? new List<string>()));
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual(0, result.MessageCode);
+            Assert.AreEqual(32, result.EventToken.Length);
+
+
+            // get and check the event
+            getRequest = GetBasicEventRequest(result.EventToken);
+            getResult = getRequest.GetAsync().Result;
+            Debug.WriteLine(getResult.Message);
+            Debug.WriteLineIf((getResult.Errors != null && getResult.Errors.Count >= 1), string.Join("; ", getResult.Errors ?? new List<string>()));
+            Assert.IsTrue(getResult.Success);
+            Assert.AreEqual(0, getResult.MessageCode);
+
+            CheckResponseAndResult(updateRequest, getResult, EventStateEnum.Active);
+
+        }
+
+        [TestMethod]
+        public void TestUpdateEventToFrench()
+        {
+            var createRequest = GetBasicEventRequest();
+
+            Debug.WriteLine("creating event");
+            var errors = new Collection<string>();
+            if (!createRequest.TryValidate(errors))
+            {
+                foreach (var error in errors)
+                {
+                    Debug.WriteLine(error);
+                }
+            }
+
+            var result = createRequest.PostAsync().Result;
+            Debug.WriteLine(result.Message);
+            Debug.WriteLineIf((result.Errors != null && result.Errors.Count >= 1), string.Join("; ", result.Errors ?? new List<string>()));
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual(0, result.MessageCode);
+            Assert.AreEqual(32, result.EventToken.Length);
+
+
+            // get and check the event
+            Debug.WriteLine($"getting event with token: {result.EventToken}");
+            var getRequest = GetBasicEventRequest(result.EventToken);
+            var getResult = getRequest.GetAsync().Result;
+            Debug.WriteLine(getResult.Message);
+            Debug.WriteLineIf((getResult.Errors != null && getResult.Errors.Count >= 1), string.Join("; ", getResult.Errors ?? new List<string>()));
+            Assert.IsTrue(getResult.Success);
+            Assert.AreEqual(0, getResult.MessageCode);
+
+            CheckResponseAndResult(createRequest, getResult, EventStateEnum.New);
+
+
+            // update the createRequest
+            Debug.WriteLine($"updating event with token: {result.EventToken}");
+            var updateRequest = createRequest;
+            updateRequest.LanguageCode = LanguageCode.fr;
+            updateRequest.EventToken = result.EventToken;
+            updateRequest.Name += " (fr)";
+            updateRequest.Description += " (fr)";
+            updateRequest.TermsAndConditionsContent += " (fr)";
+            updateRequest.RefundPolicyContent += " (fr)";
+
+            updateRequest.State = new State()
+            {
+                Code = EventStateEnum.New.ToString(),
+                Name = EventStateEnum.New.ToString()
+            };
+
+            updateRequest.Items.First().Name += " (fr)";
+            updateRequest.Items.First().Description += " (fr)";
+            updateRequest.Items.First().UnitQuantityDescription += " (fr)";
+            updateRequest.Items.First().CustomFields.First().Name += " (fr)";
+            updateRequest.Items.First().CustomFields.First().DefaultValue += " (fr)";
+
+            errors = new Collection<string>();
+            if (!updateRequest.TryValidate(errors))
+            {
+                foreach (var error in errors)
+                {
+                    Debug.WriteLine(error);
+                }
+            }
+
+            result = updateRequest.PutAsync().Result;
+            Debug.WriteLine(result.Message);
+            Debug.WriteLineIf((result.Errors != null && result.Errors.Count >= 1), string.Join("; ", result.Errors ?? new List<string>()));
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual(0, result.MessageCode);
+            Assert.AreEqual(32, result.EventToken.Length);
+
+
+            // get and check the event
+            Debug.WriteLine($"getting event with token: {result.EventToken}");
+            getRequest = GetBasicEventRequest(result.EventToken);
+            getRequest.LanguageCode = LanguageCode.fr;
+            getResult = getRequest.GetAsync().Result;
+            Debug.WriteLine(getResult.Message);
+            Debug.WriteLineIf((getResult.Errors != null && getResult.Errors.Count >= 1), string.Join("; ", getResult.Errors ?? new List<string>()));
+            Assert.IsTrue(getResult.Success);
+            Assert.AreEqual(0, getResult.MessageCode);
+
+            CheckResponseAndResult(updateRequest, getResult, EventStateEnum.New);
+
+        }
     }
 }

--- a/PelotonEppSdkTests/EventCreateTests.cs
+++ b/PelotonEppSdkTests/EventCreateTests.cs
@@ -48,8 +48,8 @@ namespace PelotonEppSdkTests
                     UnitQuantityDescription = "description for quantity"
                 }
             };
-            request.StartDate = DateTime.UtcNow;
-            request.EndDate = DateTime.UtcNow.AddDays(1);
+            request.StartDatetime = DateTime.UtcNow;
+            request.EndDatetime = DateTime.UtcNow.AddDays(1);
             request.TermsAndConditionsContent = "";
             request.RefundPolicyContent = "";
             return request;
@@ -297,8 +297,8 @@ namespace PelotonEppSdkTests
                     Name = "event item 1",
                 }
             };
-            createRequest.StartDate = DateTime.UtcNow;
-            createRequest.EndDate = DateTime.UtcNow;
+            createRequest.StartDatetime = DateTime.UtcNow;
+            createRequest.EndDatetime = DateTime.UtcNow;
             createRequest.TermsAndConditionsContent = "";
             createRequest.RefundPolicyContent = "";
 

--- a/PelotonEppSdkTests/EventTestsBase.cs
+++ b/PelotonEppSdkTests/EventTestsBase.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PelotonEppSdk.Enums;
+using PelotonEppSdk.Models;
+
+namespace PelotonEppSdkTests
+{
+    public class EventTestsBase: TestBase
+    {
+        internal static void CheckResponseAndResult(EventRequest expected, EventResponse actual, EventStateEnum eventStateCode)
+        {
+            Assert.AreEqual(32, actual.EventToken.Length);
+            Assert.AreEqual(expected.Name, actual.Name);
+            Assert.AreEqual(expected.FriendlyUrlPath, actual.FriendlyUrlPath);
+            Assert.AreEqual(expected.Description, actual.Description);
+            Assert.AreEqual(eventStateCode, actual.State);
+            Assert.AreEqual(expected.StartDate.ToString(), actual.StartDate.ToString());
+            Assert.AreEqual(expected.EndDate.ToString(), actual.EndDate.ToString());
+            if (String.IsNullOrWhiteSpace(expected.TermsAndConditionsContent))
+            {
+                Assert.AreEqual(@"By making this payment you expressly authorize the service provider, Peloton Technologies Inc., to charge your credit card for the noted dollar amount.
+You can expect that your credit card information will be transmitted securely with the utmost protection by the service provider Peloton Technologies Inc.
+If you require an adjustment to your transaction after processing has occurred, please contact one of our representatives prior to contacting the service provider, Peloton Technologies.
+If you wish to dispute a charge please contact Peloton Technologies Inc. at {0} or {1}.".Replace("\n", "")
+                    .Replace("\r", ""), actual.TermsAndConditionsContent.Replace("\n", "").Replace("\r", ""));
+            }
+            else
+            {
+                Assert.AreEqual(expected.TermsAndConditionsContent, actual.TermsAndConditionsContent);
+            }
+
+            if (String.IsNullOrWhiteSpace(expected.RefundPolicyContent))
+            {
+                Assert.AreEqual("For all refunds, please contact one of our representatives.", actual.RefundPolicyContent);
+            }
+            else
+            {
+                Assert.AreEqual(expected.RefundPolicyContent, actual.RefundPolicyContent);
+            }
+
+            // TODO: the api only saves/returns one Event Item. The rest are discarded.
+            //Assert.AreEqual(expected.Items.Count, actual.Items.Count);
+            // workaround:
+            if (expected.Items.Count >= 2)
+            {
+                Assert.AreEqual(1, actual.Items.Count);
+            }
+            else
+            {
+                Assert.AreEqual(expected.Items.Count, actual.Items.Count);
+            }
+
+            for (var i = 0; i < actual.Items.Count; i++)
+            {
+                Debug.WriteLine($"item {i}");
+
+                var expectedItem = expected.Items.ElementAt(i);
+                var actualItem = actual.Items.ElementAt(i);
+
+                //var actualItem = actual.Items.Where(ai => ai.Name == expectedItem.Name).Single();
+
+                // TODO: the name field is ignored on creation of Event POST
+                //Assert.AreEqual(expectedItem.Name, actualItem.Name);
+                // item name actually comes back as the event name
+                // workaround:
+                Assert.AreEqual(expected.Name, actualItem.Name);
+                // TODO: the description field is ignored on creation of Event POST
+                //Assert.AreEqual(expectedItem.Description, actualItem.Description);
+                // item description comes back as the event description
+                // workaround:
+                Assert.AreEqual(expected.Description, actualItem.Description);
+                Assert.AreEqual(expectedItem.QuantitySelector, actualItem.QuantitySelector);
+                // TODO: the default_unit_quantity field is ignored on creation of Event POST
+                //Assert.AreEqual(expectedItem.DefaultUnitQuantity, actualItem.DefaultUnitQuantity);
+                // item default quantity will come back un-set
+                // workaround:
+                Assert.AreEqual(default(int), actualItem.DefaultUnitQuantity);
+                Assert.AreEqual(expectedItem.UnitQuantityDescription, actualItem.UnitQuantityDescription);
+                Assert.AreEqual(expectedItem.UnitAmount, actualItem.UnitAmount);
+                Assert.AreEqual(expectedItem.Amount, actualItem.Amount);
+                // TODO: seems that the API is not returning the AmountAdjustable field on GET requests
+                //Assert.AreEqual(expectedItem.AmountAdjustable, actualItem.AmountAdjustable);
+
+                Assert.AreEqual(expectedItem.CustomFields.Count, actualItem.CustomFields.Count);
+                for (var j = 0; j < expectedItem.CustomFields.Count; j++)
+                {
+                    Debug.WriteLine($"item custom field {j}");
+                    var expectedItemCustomField = expectedItem.CustomFields.ElementAt(j);
+                    var actualItemCustomField = actualItem.CustomFields.ElementAt(j);
+
+
+
+                    Assert.AreEqual(expectedItemCustomField.Name, actualItemCustomField.Name);
+                    Assert.AreEqual(expectedItemCustomField.DefaultValue, actualItemCustomField.DefaultValue);
+                    Assert.AreEqual(expectedItemCustomField.Type, actualItemCustomField.Type);
+                    Assert.AreEqual(expectedItemCustomField.DisplayOrder, actualItemCustomField.DisplayOrder);
+                    Assert.AreEqual(expectedItemCustomField.Required, actualItemCustomField.Required);
+                }
+            }
+        }
+    }
+}

--- a/PelotonEppSdkTests/EventTestsBase.cs
+++ b/PelotonEppSdkTests/EventTestsBase.cs
@@ -16,8 +16,8 @@ namespace PelotonEppSdkTests
             Assert.AreEqual(expected.FriendlyUrlPath, actual.FriendlyUrlPath);
             Assert.AreEqual(expected.Description, actual.Description);
             Assert.AreEqual(eventStateCode, actual.State);
-            Assert.AreEqual(expected.StartDate.ToString(), actual.StartDate.ToString());
-            Assert.AreEqual(expected.EndDate.ToString(), actual.EndDate.ToString());
+            Assert.AreEqual(expected.StartDatetime.ToString(), actual.StartDatetime.ToString());
+            Assert.AreEqual(expected.EndDatetime.ToString(), actual.EndDatetime.ToString());
             if (String.IsNullOrWhiteSpace(expected.TermsAndConditionsContent))
             {
                 Assert.AreEqual(@"By making this payment you expressly authorize the service provider, Peloton Technologies Inc., to charge your credit card for the noted dollar amount.

--- a/PelotonEppSdkTests/EventsTests.cs
+++ b/PelotonEppSdkTests/EventsTests.cs
@@ -54,7 +54,7 @@ namespace PelotonEppSdkTests
             var result = eventRequest.GetAsync().Result;
             Assert.IsFalse(result.Success);
             Assert.AreEqual(1800, result.MessageCode);
-            Assert.AreEqual("EventToken must be 32 characters long.", errors.Single());
+            Assert.AreEqual("EventToken must be 32 characters in length.", errors.Single());
         }
 
         [TestMethod]
@@ -105,7 +105,7 @@ namespace PelotonEppSdkTests
                 {
                     Debug.WriteLine(error);
                 }
-                Assert.AreEqual("EventToken must be 32 characters long.", errors.Single());
+                Assert.AreEqual("EventToken must be 32 characters in length.", errors.Single());
             }
             else
             {

--- a/PelotonEppSdkTests/EventsTests.cs
+++ b/PelotonEppSdkTests/EventsTests.cs
@@ -9,7 +9,7 @@ using PelotonEppSdk.Models;
 namespace PelotonEppSdkTests
 {
     [TestClass]
-    public class EventsTests : TestBase
+    public class EventsTests : EventTestsBase
     {
         private static EventRequest GetBasicEventRequest(string token, LanguageCode languageCode = LanguageCode.en)
         {
@@ -22,7 +22,8 @@ namespace PelotonEppSdkTests
         [TestMethod]
         public void TestSuccessGetEvent()
         {
-            var eventRequest = GetBasicEventRequest("667fbd353e8d4e9d9e0611d489d5efb6");
+            var token = "667fbd353e8d4e9d9e0611d489d5efb6";
+            var eventRequest = GetBasicEventRequest(token);
             var errors = new Collection<string>();
             if (!eventRequest.TryValidate(errors))
             {
@@ -34,6 +35,8 @@ namespace PelotonEppSdkTests
             var result = eventRequest.GetAsync().Result;
             Assert.IsTrue(result.Success);
             Assert.AreEqual(0, result.MessageCode);
+
+            CheckGetResponse(token, result, LanguageCode.en);
         }
 
         [TestMethod]
@@ -102,7 +105,7 @@ namespace PelotonEppSdkTests
                 {
                     Debug.WriteLine(error);
                 }
-                Assert.AreEqual("The EventToken field is required.", errors.Single());
+                Assert.AreEqual("EventToken must be 32 characters long.", errors.Single());
             }
             else
             {
@@ -113,7 +116,8 @@ namespace PelotonEppSdkTests
         [TestMethod]
         public void TestGetEventEn()
         {
-            var eventRequest = GetBasicEventRequest("667fbd353e8d4e9d9e0611d489d5efb6", LanguageCode.en);
+            var token = "667fbd353e8d4e9d9e0611d489d5efb6";
+            var eventRequest = GetBasicEventRequest(token, LanguageCode.en);
             var errors = new Collection<string>();
             if (!eventRequest.TryValidate(errors))
             {
@@ -126,12 +130,15 @@ namespace PelotonEppSdkTests
             Assert.IsTrue(result.Success);
             Assert.AreEqual(0, result.MessageCode);
             Assert.AreEqual("Success", result.Message);
+
+            CheckGetResponse(token, result, LanguageCode.en);
         }
 
         [TestMethod]
         public void TestGetEventFr()
         {
-            var eventRequest = GetBasicEventRequest("667fbd353e8d4e9d9e0611d489d5efb6", LanguageCode.fr);
+            var token = "667fbd353e8d4e9d9e0611d489d5efb6";
+            var eventRequest = GetBasicEventRequest(token, LanguageCode.fr);
             var errors = new Collection<string>();
             if (!eventRequest.TryValidate(errors))
             {
@@ -144,6 +151,129 @@ namespace PelotonEppSdkTests
             Assert.IsTrue(result.Success);
             Assert.AreEqual(0, result.MessageCode);
             Assert.AreEqual("Réussi", result.Message);
+
+            CheckGetResponse(token, result, LanguageCode.fr);
         }
+
+        private void CheckGetResponse(string token, EventResponse actual, LanguageCode languageCode)
+        {
+            switch (token)
+            {
+                case "667fbd353e8d4e9d9e0611d489d5efb6":
+                    Assert.AreEqual(32, actual.EventToken.Length);
+                    Assert.AreEqual("Dueling over a Grand Regatta", actual.Name);
+                    Assert.AreEqual("DOG2015", actual.FriendlyUrlPath);
+                    Assert.AreEqual(null, actual.Description);
+                    Assert.AreEqual(EventStateEnum.Active, actual.State);
+                    Assert.AreEqual("2015-03-01 00:00:00", actual.StartDate.ToString());
+                    Assert.AreEqual("2015-03-27 00:00:00", actual.EndDate.ToString());
+                    if (languageCode == LanguageCode.en)
+                    {
+                        Assert.AreEqual(@"By making this payment you expressly authorize the service provider, Peloton Technologies Inc., to charge your credit card for the noted dollar amount.
+You can expect that your credit card information will be transmitted securely with the utmost protection by the service provider Peloton Technologies Inc.
+If you require an adjustment to your transaction after processing has occurred, please contact one of our representatives prior to contacting the service provider, Peloton Technologies.
+If you wish to dispute a charge please contact Peloton Technologies Inc. at {0} or {1}.".Replace("\n", "")
+                            .Replace("\r", ""), actual.TermsAndConditionsContent.Replace("\n", "").Replace("\r", ""));
+
+                        Assert.AreEqual("For all refunds, please contact one of our representatives.", actual.RefundPolicyContent);
+                    }
+
+                    if (languageCode == LanguageCode.fr)
+                    {
+                        Assert.AreEqual(@"En faisant ce paiement, vous autorisez expressément le fournisseur de services, Peloton Technologies Inc., de débiter votre carte de crédit pour le montant indiqué.Vous pouvez vous attendre que vos informations de carte de crédit sera transmis en toute sécurité avec la plus grande protection par le fournisseur de services Peloton Technologies Inc.Si vous avez besoin d'un ajustement à votre transaction après le traitement a eu lieu, s'il vous plaît contacter un de nos représentants avant de communiquer avec le fournisseur de services, Peloton Technologies. Si vous souhaitez contester une accusation s'il vous plaît contacter Peloton Technologies Inc. à {0} ou {1}.".Replace("\n", "")
+                            .Replace("\r", ""), actual.TermsAndConditionsContent.Replace("\n", "").Replace("\r", ""));
+
+                        Assert.AreEqual("Pour tous les remboursements, s'il vous plaît contacter un de nos représentants.", actual.RefundPolicyContent);
+                    }
+
+                    // TODO: the api only saves/returns one Event Item. The rest are discarded.
+                    //Assert.AreEqual(expected.Items.Count, actual.Items.Count);
+                    Assert.AreEqual(1, actual.Items.Count);
+
+
+                    for (var i = 0; i < actual.Items.Count; i++)
+                    {
+                        Debug.WriteLine($"item {i}");
+
+
+                        var actualItem = actual.Items.ElementAt(i);
+
+                        // TODO: the name field is ignored on creation of Event POST
+                        //Assert.AreEqual(expectedItem.Name, actualItem.Name);
+                        // item name actually comes back as the event name
+                        // workaround:
+                        Assert.AreEqual("Dueling over a Grand Regatta", actualItem.Name);
+                        // TODO: the description field is ignored on creation of Event POST
+                        //Assert.AreEqual(expectedItem.Description, actualItem.Description);
+                        // item description comes back as the event description
+                        // workaround:
+                        Assert.AreEqual(null, actualItem.Description);
+                        Assert.AreEqual(false, actualItem.QuantitySelector);
+                        // TODO: the default_unit_quantity field is ignored on creation of Event POST
+                        //Assert.AreEqual(expectedItem.DefaultUnitQuantity, actualItem.DefaultUnitQuantity);
+                        // item default quantity will come back un-set
+                        // workaround:
+                        Assert.AreEqual(default(int), actualItem.DefaultUnitQuantity);
+                        Assert.AreEqual(null, actualItem.UnitQuantityDescription);
+                        Assert.AreEqual(0, actualItem.UnitAmount);
+                        Assert.AreEqual(0, actualItem.Amount);
+                        // TODO: seems that the API is not returning the AmountAdjustable field on GET requests
+                        //Assert.AreEqual(expectedItem.AmountAdjustable, actualItem.AmountAdjustable);
+
+                        Assert.AreEqual(5, actualItem.CustomFields.Count);
+
+                        Debug.WriteLine($"item custom field {0}");
+
+                        var actualItemCustomField = actualItem.CustomFields.ElementAt(0);
+
+                        Assert.AreEqual("Race Name", actualItemCustomField.Name);
+                        Assert.AreEqual(null, actualItemCustomField.DefaultValue);
+                        Assert.AreEqual(EventCustomFieldTypeEnum.@string, actualItemCustomField.Type);
+                        Assert.AreEqual(0, actualItemCustomField.DisplayOrder);
+                        Assert.AreEqual(true, actualItemCustomField.Required);
+
+                        Debug.WriteLine($"item custom field {1}");
+                        actualItemCustomField = actualItem.CustomFields.ElementAt(1);
+
+                        Assert.AreEqual("Participant Name", actualItemCustomField.Name);
+                        Assert.AreEqual(null, actualItemCustomField.DefaultValue);
+                        Assert.AreEqual(EventCustomFieldTypeEnum.@string, actualItemCustomField.Type);
+                        Assert.AreEqual(1, actualItemCustomField.DisplayOrder);
+                        Assert.AreEqual(true, actualItemCustomField.Required);
+
+                        Debug.WriteLine($"item custom field {2}");
+                        actualItemCustomField = actualItem.CustomFields.ElementAt(2);
+
+                        Assert.AreEqual("Other 1", actualItemCustomField.Name);
+                        Assert.AreEqual(null, actualItemCustomField.DefaultValue);
+                        Assert.AreEqual(EventCustomFieldTypeEnum.@string, actualItemCustomField.Type);
+                        Assert.AreEqual(2, actualItemCustomField.DisplayOrder);
+                        Assert.AreEqual(false, actualItemCustomField.Required);
+
+                        Debug.WriteLine($"item custom field {3}");
+                        actualItemCustomField = actualItem.CustomFields.ElementAt(3);
+
+                        Assert.AreEqual("Other 2", actualItemCustomField.Name);
+                        Assert.AreEqual(null, actualItemCustomField.DefaultValue);
+                        Assert.AreEqual(EventCustomFieldTypeEnum.@string, actualItemCustomField.Type);
+                        Assert.AreEqual(3, actualItemCustomField.DisplayOrder);
+                        Assert.AreEqual(false, actualItemCustomField.Required);
+
+                        Debug.WriteLine($"item custom field {4}");
+                        actualItemCustomField = actualItem.CustomFields.ElementAt(4);
+
+                        Assert.AreEqual("Other 3", actualItemCustomField.Name);
+                        Assert.AreEqual(null, actualItemCustomField.DefaultValue);
+                        Assert.AreEqual(EventCustomFieldTypeEnum.@string, actualItemCustomField.Type);
+                        Assert.AreEqual(4, actualItemCustomField.DisplayOrder);
+                        Assert.AreEqual(false, actualItemCustomField.Required);
+
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
+
     }
 }

--- a/PelotonEppSdkTests/EventsTests.cs
+++ b/PelotonEppSdkTests/EventsTests.cs
@@ -165,8 +165,8 @@ namespace PelotonEppSdkTests
                     Assert.AreEqual("DOG2015", actual.FriendlyUrlPath);
                     Assert.AreEqual(null, actual.Description);
                     Assert.AreEqual(EventStateEnum.Active, actual.State);
-                    Assert.AreEqual("2015-03-01 00:00:00", actual.StartDate.ToString());
-                    Assert.AreEqual("2015-03-27 00:00:00", actual.EndDate.ToString());
+                    Assert.AreEqual("2015-03-01 00:00:00", actual.StartDatetime.ToString());
+                    Assert.AreEqual("2015-03-27 00:00:00", actual.EndDatetime.ToString());
                     if (languageCode == LanguageCode.en)
                     {
                         Assert.AreEqual(@"By making this payment you expressly authorize the service provider, Peloton Technologies Inc., to charge your credit card for the noted dollar amount.

--- a/PelotonEppSdkTests/FundsTransferNotificationsTests.cs
+++ b/PelotonEppSdkTests/FundsTransferNotificationsTests.cs
@@ -161,10 +161,9 @@ namespace PelotonEppSdkTests
             var transfer = GetBasicFundsTransferRequest();
             transfer.References = null;
 
-            var validationResults = transfer.Validate();
-            if (validationResults.Any())
+            if (!transfer.TryValidate(errors))
             {
-                foreach (var validationResult in validationResults)
+                foreach (var validationResult in errors)
                 {
                     Debug.WriteLine(validationResult);
                 }

--- a/PelotonEppSdkTests/FundsTransferTests.cs
+++ b/PelotonEppSdkTests/FundsTransferTests.cs
@@ -112,7 +112,7 @@ namespace PelotonEppSdkTests
             var errors = new Collection<string>();
             if (transfer.TryValidate(errors)) Assert.Fail();
             Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual("AccountToken must be 32 characters long.", errors.FirstOrDefault());
+            Assert.AreEqual("AccountToken must be 32 characters in length.", errors.FirstOrDefault());
         }
 
         [TestMethod]
@@ -123,7 +123,7 @@ namespace PelotonEppSdkTests
             var errors = new Collection<string>();
             if (transfer.TryValidate(errors)) Assert.Fail();
             Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual("AccountToken must be 32 characters long.", errors.FirstOrDefault());
+            Assert.AreEqual("AccountToken must be 32 characters in length.", errors.FirstOrDefault());
         }
 
         [TestMethod]
@@ -156,7 +156,7 @@ namespace PelotonEppSdkTests
             var errors = new Collection<string>();
             if (transfer.TryValidate(errors)) Assert.Fail();
             Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual("AccountToken must be 32 characters long.", errors.FirstOrDefault());
+            Assert.AreEqual("AccountToken must be 32 characters in length.", errors.FirstOrDefault());
         }
 
         [TestMethod]
@@ -167,7 +167,7 @@ namespace PelotonEppSdkTests
             var errors = new Collection<string>();
             if (transfer.TryValidate(errors)) Assert.Fail();
             Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual("AccountToken must be 32 characters long.", errors.FirstOrDefault());
+            Assert.AreEqual("AccountToken must be 32 characters in length.", errors.FirstOrDefault());
         }
 
         [TestMethod]

--- a/PelotonEppSdkTests/PelotonEppSdkTests.csproj
+++ b/PelotonEppSdkTests/PelotonEppSdkTests.csproj
@@ -59,6 +59,7 @@
     <Compile Include="CreditCardTransactionTokenRequestTests.cs" />
     <Compile Include="EventCreateTests.cs" />
     <Compile Include="EventsTests.cs" />
+    <Compile Include="EventTestsBase.cs" />
     <Compile Include="FundsTransferNotificationsTests.cs" />
     <Compile Include="FundsTransferTests.cs" />
     <Compile Include="StatementsTests.cs" />

--- a/PelotonEppSdkTests/StatementsTests.cs
+++ b/PelotonEppSdkTests/StatementsTests.cs
@@ -127,7 +127,7 @@ namespace PelotonEppSdkTests
             }
 
             Assert.IsTrue(errors.Count == 1);
-            Assert.AreEqual("AccountToken must be 32 characters in length", errors.Single());
+            Assert.AreEqual("AccountToken must be 32 characters in length.", errors.Single());
 
             var result = request.PostAsync().Result;
             Debug.WriteLine("details count: " + result.StatementDetails?.Count);

--- a/PelotonEppSdkTests/TransfersTests.cs
+++ b/PelotonEppSdkTests/TransfersTests.cs
@@ -78,7 +78,7 @@ namespace PelotonEppSdkTests
             var errors = new Collection<string>();
             if (transfer.TryValidate(errors)) Assert.Fail();
             Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual("SourceAccountToken must be 32 characters long.", errors.FirstOrDefault());
+            Assert.AreEqual("SourceAccountToken must be 32 characters in length.", errors.FirstOrDefault());
         }
 
         [TestMethod]
@@ -89,7 +89,7 @@ namespace PelotonEppSdkTests
             var errors = new Collection<string>();
             if (transfer.TryValidate(errors)) Assert.Fail();
             Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual("TargetAccountToken must be 32 characters long.", errors.FirstOrDefault());
+            Assert.AreEqual("TargetAccountToken must be 32 characters in length.", errors.FirstOrDefault());
         }
 
         [TestMethod]
@@ -100,7 +100,7 @@ namespace PelotonEppSdkTests
             var errors = new Collection<string>();
             if (transfer.TryValidate(errors)) Assert.Fail();
             Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual("SourceAccountToken must be 32 characters long.", errors.FirstOrDefault());
+            Assert.AreEqual("SourceAccountToken must be 32 characters in length.", errors.FirstOrDefault());
         }
 
         [TestMethod]
@@ -111,7 +111,7 @@ namespace PelotonEppSdkTests
             var errors = new Collection<string>();
             if (transfer.TryValidate(errors)) Assert.Fail();
             Assert.AreEqual(1, errors.Count);
-            Assert.AreEqual("TargetAccountToken must be 32 characters long.", errors.FirstOrDefault());
+            Assert.AreEqual("TargetAccountToken must be 32 characters in length.", errors.FirstOrDefault());
         }
 
         [TestMethod]

--- a/PelotonEppSdkTests/TransfersTests.cs
+++ b/PelotonEppSdkTests/TransfersTests.cs
@@ -34,8 +34,9 @@ namespace PelotonEppSdkTests
             var transfer = GetBasicRequest();
             transfer.References = null;
 
-            var validationResults = transfer.Validate();
-            if (validationResults.Any())
+            var validationResults = new List<string>();
+            var validationSuccess = transfer.TryValidate(validationResults);
+            if (!validationSuccess)
             {
                 foreach (var validationResult in validationResults)
                 {


### PR DESCRIPTION
Implemented support for Event API POST and PUT methods (aka Event create and update methods).

The tests checkout the "happy path" and a few other scenarios.

Some caveats:
- EventItem Name and Description are thrown away when calling POST or PUT and the value in the GET response is the same as the EventRequest Name and Description fields;
- EventItem AmountAdjustable boolean is not returned from the GET response (though it is set correctly on POST and PUT) (This is likely an API bug, not an SDK bug); (This will be fixed in the next release of the API)
- EventItem DefaultUnitQuantity is not returned from the GET response and I believe the value is discarded by the API in the POST and PUT methods;
- Only a single EventItem is supported by the Event API -- additional EventItems in the POST or PUT will be discarded.