### PR TITLE
Added public default constructors to the *Response classes

### DIFF
--- a/PelotonEppSdk/Models/BankAccountCreateResponse.cs
+++ b/PelotonEppSdk/Models/BankAccountCreateResponse.cs
@@ -6,6 +6,11 @@ namespace PelotonEppSdk.Models
     {
         public string BankAccountToken { get; set; }
 
+        // ReSharper disable once UnusedMember.Global
+        public BankAccountCreateResponse()
+        {
+        }
+
         internal BankAccountCreateResponse(response r) : base(r)
         {
         }
@@ -15,7 +20,7 @@ namespace PelotonEppSdk.Models
     [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
     [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global")]
     [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
-    internal class bank_account_response: response
+    internal class bank_account_response : response
     {
         public string bank_account_token { get; set; }
 

--- a/PelotonEppSdk/Models/ClientAuthTokenResponse.cs
+++ b/PelotonEppSdk/Models/ClientAuthTokenResponse.cs
@@ -6,7 +6,7 @@ using PelotonEppSdk.Enums;
 
 namespace PelotonEppSdk.Models
 {
-    public class ClientAuthTokenResponse: Response
+    public class ClientAuthTokenResponse : Response
     {
         /// <summary>
         /// The one-time-use client authorization token (CAT).
@@ -58,6 +58,11 @@ namespace PelotonEppSdk.Models
         /// </summary>
         public DateTime? AuthorizedDatetime { get; set; }
 
+        // ReSharper disable once UnusedMember.Global
+        public ClientAuthTokenResponse()
+        {
+        }
+
         internal ClientAuthTokenResponse(response r) : base(r)
         {
         }
@@ -67,7 +72,7 @@ namespace PelotonEppSdk.Models
     [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
     [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global")]
     [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
-    internal class client_auth_token_response: response
+    internal class client_auth_token_response : response
     {
         public string client_auth_token { get; set; }
 
@@ -85,7 +90,7 @@ namespace PelotonEppSdk.Models
     [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
     [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global")]
     [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
-    internal class client_auth_token_status_response: response
+    internal class client_auth_token_status_response : response
     {
         public string client_auth_token { get; set; }
 

--- a/PelotonEppSdk/Models/CreditCardResponse.cs
+++ b/PelotonEppSdk/Models/CreditCardResponse.cs
@@ -3,7 +3,7 @@ using PelotonEppSdk.Interfaces;
 
 namespace PelotonEppSdk.Models
 {
-    public class CreditCardResponse: Response, IVerificationResponse
+    public class CreditCardResponse : Response, IVerificationResponse
     {
         /// <summary>
         /// The credit card token assigned to the newly created credit card
@@ -20,6 +20,11 @@ namespace PelotonEppSdk.Models
         /// </summary>
         public string CardSecurityCodeVerificationResult { get; set; }
 
+        // ReSharper disable once UnusedMember.Global
+        public CreditCardResponse()
+        {
+        }
+
         internal CreditCardResponse(response r) : base(r)
         {
         }
@@ -29,7 +34,7 @@ namespace PelotonEppSdk.Models
     [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
     [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global")]
     [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
-    internal class credit_card_response: response, Iverification_response
+    internal class credit_card_response : response, Iverification_response
     {
         public string credit_card_token { get; set; }
 

--- a/PelotonEppSdk/Models/CreditCardTransactionResponse.cs
+++ b/PelotonEppSdk/Models/CreditCardTransactionResponse.cs
@@ -3,7 +3,7 @@ using PelotonEppSdk.Interfaces;
 
 namespace PelotonEppSdk.Models
 {
-    public class CreditCardTransactionResponse: TransactionResponse, IVerificationResponse
+    public class CreditCardTransactionResponse : TransactionResponse, IVerificationResponse
     {
         /// <summary>
         /// Result of the address verification process
@@ -14,6 +14,11 @@ namespace PelotonEppSdk.Models
         /// Result of the card security code verification process
         /// </summary>
         public string CardSecurityCodeVerificationResult { get; set; }
+
+        // ReSharper disable once UnusedMember.Global
+        public CreditCardTransactionResponse()
+        {
+        }
 
         internal CreditCardTransactionResponse(response r) : base(r)
         {

--- a/PelotonEppSdk/Models/FundsTransferNotificationsResponse.cs
+++ b/PelotonEppSdk/Models/FundsTransferNotificationsResponse.cs
@@ -16,6 +16,11 @@ namespace PelotonEppSdk.Models
         /// </summary>
         public string Token { get; set; }
 
+        // ReSharper disable once UnusedMember.Global
+        public FundsTransferNotificationsResponse()
+        {
+        }
+
         internal FundsTransferNotificationsResponse(response r) : base(r)
         {
         }
@@ -23,6 +28,7 @@ namespace PelotonEppSdk.Models
 
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
+    [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global")]
     [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
     internal class funds_transfer_notifications_response : response
     {

--- a/PelotonEppSdk/Models/StatementsResponse.cs
+++ b/PelotonEppSdk/Models/StatementsResponse.cs
@@ -29,6 +29,11 @@ namespace PelotonEppSdk.Models
         /// </summary>
         public DateTime ToDate { get; set; }
 
+        // ReSharper disable once UnusedMember.Global
+        public StatementsResponse()
+        {
+        }
+
         internal StatementsResponse(response sr) : base(sr)
         {
         }
@@ -128,7 +133,7 @@ namespace PelotonEppSdk.Models
             {
                 OpeningBalance = sr.opening_balance,
                 // In some error cases the statement_details will be null, so use the null propagation operator here
-                StatementDetails = sr.statement_details?.Select(sd => (StatementDetail)sd).ToList(),
+                StatementDetails = sr.statement_details?.Select(sd => (StatementDetail) sd).ToList(),
                 FromDate = sr.from_date_utc,
                 ToDate = sr.to_date_utc
             };
@@ -173,9 +178,9 @@ namespace PelotonEppSdk.Models
                 Amount = sd.amount,
                 TransactionDatetime = sd.transaction_datetime_utc,
                 TransactionReferenceCode = sd.transaction_reference_code,
-                TransactionDescription = (TransactionDescription)sd.transaction_description,
-                TransactionType = (StatementTransactionType)sd.transaction_type,
-                References = sd.references.Select(r => (Reference)r).ToList()
+                TransactionDescription = (TransactionDescription) sd.transaction_description,
+                TransactionType = (StatementTransactionType) sd.transaction_type,
+                References = sd.references.Select(r => (Reference) r).ToList()
             };
         }
     }
@@ -207,7 +212,7 @@ namespace PelotonEppSdk.Models
             };
         }
     }
-    
+
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global")]
     [SuppressMessage("ReSharper", "CollectionNeverUpdated.Global")]
@@ -236,5 +241,4 @@ namespace PelotonEppSdk.Models
             };
         }
     }
-    
 }

--- a/PelotonEppSdk/Models/TransactionResponse.cs
+++ b/PelotonEppSdk/Models/TransactionResponse.cs
@@ -14,7 +14,9 @@ namespace PelotonEppSdk.Models
         [StringLength(36)]
         public string TransactionRefCode { get; set; }
 
-        public TransactionResponse() : base()
+        // ReSharper disable once UnusedMember.Global
+        // ReSharper disable once MemberCanBeProtected.Global
+        public TransactionResponse()
         {
         }
 

--- a/PelotonEppSdk/Properties/AssemblyInfo.cs
+++ b/PelotonEppSdk/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.1.1")]
-[assembly: AssemblyFileVersion("1.0.1.1")]
+[assembly: AssemblyVersion("1.1.1.0")]
+[assembly: AssemblyFileVersion("1.1.1.0")]
 
 [assembly: InternalsVisibleTo("PelotonEppSdkTests")]


### PR DESCRIPTION
Added public default constructors to the *Response classes, so that third-parties can instantiate them for testing purposes.

Previously, these classes had internal-only constructors, which disabled the automatic default constructor that would otherwise have been provided.

Resolves issue #15 