### PR TITLE
Refactored the PelotonClient to use NewtonSoft.Json serializer

### DIFF
--- a/PelotonEppSdk/Classes/PelotonClient.cs
+++ b/PelotonEppSdk/Classes/PelotonClient.cs
@@ -4,7 +4,7 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using System.Web;
-using System.Web.Script.Serialization;
+using Newtonsoft.Json;
 using PelotonEppSdk.Enums;
 using PelotonEppSdk.Models;
 
@@ -24,9 +24,7 @@ namespace PelotonEppSdk.Classes
         /// <exception cref="NotImplementedException"><see cref="RequestType"/> GET is not yet supported.</exception>
         private async Task<T> MakeBasicHttpRequest<T>(RequestType type, request_base content, ApiTarget target, string parameter)
         {
-            var serializer = new JavaScriptSerializer();
-            serializer.MaxJsonLength = int.MaxValue;
-            var serializedContent = serializer.Serialize(content);
+            var serializedContent = JsonConvert.SerializeObject(content);
             var stringContent = new StringContent(serializedContent, Encoding.UTF8, "application/json");
             using (var client = new HttpClient())
             {
@@ -57,7 +55,7 @@ namespace PelotonEppSdk.Classes
                 string stringResult = await httpResponseMessage.Content.ReadAsStringAsync().ConfigureAwait(false);
                 if (!string.IsNullOrEmpty(stringResult))
                 {
-                    return serializer.Deserialize<T>(stringResult);
+                    return JsonConvert.DeserializeObject<T>(stringResult);
                 }
 
                 // handle server errors

--- a/PelotonEppSdk/PelotonEppSdk.csproj
+++ b/PelotonEppSdk/PelotonEppSdk.csproj
@@ -31,6 +31,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Build.Framework" />
+    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
@@ -103,6 +107,7 @@
     <Compile Include="Validations\DollarValueValidationAttribute.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/PelotonEppSdk/packages.config
+++ b/PelotonEppSdk/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net452" />
+</packages>


### PR DESCRIPTION
Refactored the PelotonClient to use NewtonSoft.Json SerializerObject/DeserializeObject instead of JavaScriptSerializer because of a bug in the deserialization of UTC datetimes.