### PR TITLE
Add support for optional Account token properties

### DIFF
--- a/PelotonEppSdk/Interfaces/IOptionalAccountToken.cs
+++ b/PelotonEppSdk/Interfaces/IOptionalAccountToken.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
+
+namespace PelotonEppSdk.Interfaces
+{
+    public interface IOptionalAccountToken
+    {
+        /// <summary>
+        /// The token used to identify the Peloton account.
+        /// Required when more than one account is available.
+        /// </summary>
+        [StringLength(32, MinimumLength = 32)]
+        string AccountToken { get; set; }
+    }
+
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
+    [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
+    public interface Ioptional_account_token
+    {
+        string account_token { get; set; }
+    }
+}

--- a/PelotonEppSdk/Models/CreditCardRequest.cs
+++ b/PelotonEppSdk/Models/CreditCardRequest.cs
@@ -4,14 +4,13 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
-using System.Web;
 using PelotonEppSdk.Classes;
 using PelotonEppSdk.Enums;
 using PelotonEppSdk.Interfaces;
 
 namespace PelotonEppSdk.Models
 {
-    public class CreditCardRequest : RequestBase, ICreditCardCreateRequest, ICreditCardDeleteRequest, ICreditCardUpdateRequest
+    public class CreditCardRequest : RequestBase, ICreditCardCreateRequest, ICreditCardDeleteRequest, ICreditCardUpdateRequest, IOptionalAccountToken
     {
         public CreditCardRequest()
         {
@@ -19,6 +18,9 @@ namespace PelotonEppSdk.Models
         }
 
         public string CreditCardToken { get; set; }
+
+        /// <inheritdoc cref="IOptionalAccountToken.AccountToken"/>
+        public string AccountToken { get; set; }
 
         /// <summary>
         /// Recommended: Order number provided by the source system, otherwise one will be automatically generated
@@ -117,8 +119,10 @@ namespace PelotonEppSdk.Models
     [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
     [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global")]
     [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
-    internal class credit_card_request : request_base
+    internal class credit_card_request : request_base, Ioptional_account_token
     {
+        public string account_token { get; set; }
+
         public string order_number { get; set; }
 
         public string name_on_card { get; set; }
@@ -149,6 +153,7 @@ namespace PelotonEppSdk.Models
         {
             return new credit_card_request(creditCardRequest)
             {
+                account_token = creditCardRequest.AccountToken,
                 order_number = creditCardRequest.OrderNumber,
                 name_on_card = creditCardRequest.CardOwner,
                 card_number = creditCardRequest.CardNumber,

--- a/PelotonEppSdk/Models/CreditCardTokenTransactionRequest.cs
+++ b/PelotonEppSdk/Models/CreditCardTokenTransactionRequest.cs
@@ -5,18 +5,21 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
-using System.Web;
 using PelotonEppSdk.Classes;
 using PelotonEppSdk.Enums;
+using PelotonEppSdk.Interfaces;
 
 namespace PelotonEppSdk.Models
 {
-    public class CreditCardTokenTransactionRequest : RequestBase
+    public class CreditCardTokenTransactionRequest : RequestBase, IOptionalAccountToken
     {
   	    public CreditCardTokenTransactionRequest()
   	    {
             References = new List<Reference>();
         }
+
+        /// <inheritdoc cref="IOptionalAccountToken.AccountToken"/>
+        public string AccountToken { get; set; }
 
 		/// <summary>
         /// Recommended: Order number provided by the source system, otherwise one will be automatically generated
@@ -109,8 +112,10 @@ namespace PelotonEppSdk.Models
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
     [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
-    internal class credit_card_token_transaction_request : request_base
+    internal class credit_card_token_transaction_request : request_base, Ioptional_account_token
     {
+        public string account_token { get; set; }
+
         public string order_number { get; set; }
 
         public string credit_card_token { get; set; }
@@ -145,6 +150,7 @@ namespace PelotonEppSdk.Models
         {
             return new credit_card_token_transaction_request(creditCardTokenTransactionRequest)
             {
+                account_token = creditCardTokenTransactionRequest.AccountToken,
                 order_number = creditCardTokenTransactionRequest.OrderNumber,
                 credit_card_token = creditCardTokenTransactionRequest.CreditCardToken,
                 amount = creditCardTokenTransactionRequest.Amount,

--- a/PelotonEppSdk/Models/CreditCardTransactionRequest.cs
+++ b/PelotonEppSdk/Models/CreditCardTransactionRequest.cs
@@ -7,15 +7,19 @@ using System.Net;
 using System.Threading.Tasks;
 using PelotonEppSdk.Classes;
 using PelotonEppSdk.Enums;
+using PelotonEppSdk.Interfaces;
 
 namespace PelotonEppSdk.Models
 {
-    public class CreditCardTransactionRequest : RequestBase
+    public class CreditCardTransactionRequest : RequestBase, IOptionalAccountToken
     {
   	    public CreditCardTransactionRequest()
   	    {
             References = new List<Reference>();
         }
+
+        /// <inheritdoc cref="IOptionalAccountToken.AccountToken"/>
+        public string AccountToken { get; set; }
 
         /// <summary>
         /// The name of the card owner as it appears on the credit card
@@ -131,8 +135,10 @@ namespace PelotonEppSdk.Models
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
     [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
-    internal class credit_card_transaction_request : request_base
+    internal class credit_card_transaction_request : request_base, Ioptional_account_token
     {
+        public string account_token { get; set; }
+
         public string name_on_card { get; set; }
 
         public long? card_number { get; set; }
@@ -175,6 +181,7 @@ namespace PelotonEppSdk.Models
         {
             return new credit_card_transaction_request(creditCardTransactionRequest)
             {
+                account_token = creditCardTransactionRequest.AccountToken,
                 card_number = creditCardTransactionRequest.CardNumber,
                 name_on_card = creditCardTransactionRequest.CardOwner,
                 expiry_month = creditCardTransactionRequest.ExpiryMonth,

--- a/PelotonEppSdk/Models/FundsTransferNotificationsRequest.cs
+++ b/PelotonEppSdk/Models/FundsTransferNotificationsRequest.cs
@@ -4,11 +4,15 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using PelotonEppSdk.Classes;
 using PelotonEppSdk.Enums;
+using PelotonEppSdk.Interfaces;
 
 namespace PelotonEppSdk.Models
 {
-    public class FundsTransferNotificationsRequest : RequestBase
+    public class FundsTransferNotificationsRequest : RequestBase, IOptionalAccountToken
     {
+        /// <inheritdoc cref="IOptionalAccountToken.AccountToken"/>
+        public string AccountToken { get; set; }
+
         /// <summary>
         /// The token representing the date and time for which notifications will be provided
         /// </summary>
@@ -27,6 +31,8 @@ namespace PelotonEppSdk.Models
             if (Items.HasValue)
                 parameter = parameter + "?items=" + Items;
             parameter = parameter + "&application_name=" + ApplicationName;
+            if (!string.IsNullOrWhiteSpace(AccountToken))
+                parameter = parameter + $"&{nameof(funds_transfer_notifications_request.account_token)}=" + AccountToken;
             var result = await client.GetAsync<funds_transfer_notifications_response>((funds_transfer_notifications_request)this, ApiTarget.FundsTransferNotifications, parameter).ConfigureAwait(false);
             return (FundsTransferNotificationsResponse)result;
         }
@@ -35,8 +41,10 @@ namespace PelotonEppSdk.Models
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
     [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
-    internal class funds_transfer_notifications_request : request_base
+    internal class funds_transfer_notifications_request : request_base, Ioptional_account_token
     {
+        public string account_token { get; set; }
+
         [Required]
         public string token { get; set; }
 
@@ -48,6 +56,7 @@ namespace PelotonEppSdk.Models
         {
             return new funds_transfer_notifications_request(fundsTransferNotificationsRequest)
             {
+                account_token = fundsTransferNotificationsRequest.AccountToken,
                 token = fundsTransferNotificationsRequest.Token,
                 items = fundsTransferNotificationsRequest.Items,
                 application_name = fundsTransferNotificationsRequest.ApplicationName,

--- a/PelotonEppSdk/Models/FundsTransferNotificationsTokenRequest.cs
+++ b/PelotonEppSdk/Models/FundsTransferNotificationsTokenRequest.cs
@@ -4,11 +4,15 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using PelotonEppSdk.Classes;
 using PelotonEppSdk.Enums;
+using PelotonEppSdk.Interfaces;
 
 namespace PelotonEppSdk.Models
 {
-    public class FundsTransferNotificationsTokenRequest : RequestBase
+    public class FundsTransferNotificationsTokenRequest : RequestBase, IOptionalAccountToken
     {
+        /// <inheritdoc cref="IOptionalAccountToken.AccountToken"/>
+        public string AccountToken { get; set; }
+
         /// <summary>
         /// Sets the date associated with the token, from which the Funds Transfers Notifications will be returned
         /// </summary>
@@ -26,8 +30,10 @@ namespace PelotonEppSdk.Models
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
     [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
-    internal class funds_transfer_token_request : request_base
+    internal class funds_transfer_token_request : request_base, Ioptional_account_token
     {
+        public string account_token { get; set; }
+
         [Required]
         public string from_date_utc { get; set; }
 
@@ -37,6 +43,7 @@ namespace PelotonEppSdk.Models
         {
             return new funds_transfer_token_request(fundsTransferNotificationsRequest)
             {
+                account_token = fundsTransferNotificationsRequest.AccountToken,
                 from_date_utc = fundsTransferNotificationsRequest.FromDateUtc,
                 application_name = fundsTransferNotificationsRequest.ApplicationName,
                 authentication_header = fundsTransferNotificationsRequest.AuthenticationHeader,

--- a/PelotonEppSdkTests/BankAccountCreateTests.cs
+++ b/PelotonEppSdkTests/BankAccountCreateTests.cs
@@ -56,7 +56,7 @@ namespace PelotonEppSdkTests
             var createRequest = factory.GetBankAccountCreateRequest();
             createRequest.BankAccount = new BankAccount
             {
-                AccountNumber = "1",
+                AccountNumber = "1234567890",
                 BranchTransitNumber = 1,
                 CurrencyCode = "CAD",
                 FinancialInstitution = 1,

--- a/PelotonEppSdkTests/ClientAuthTokenTests.cs
+++ b/PelotonEppSdkTests/ClientAuthTokenTests.cs
@@ -84,7 +84,7 @@ namespace PelotonEppSdkTests
             Assert.AreEqual(1, result.MessageCode);
             Assert.AreEqual("Validation Error", result.Message);
             Assert.IsTrue(string.IsNullOrEmpty(result.ClientAuthToken));
-            Assert.AreEqual("account_token: invalid", result.Errors.Single());
+            Assert.AreEqual("account_token: not found", result.Errors.Single());
         }
 
         [TestMethod]

--- a/PelotonEppSdkTests/FundsTransferNotificationsTests.cs
+++ b/PelotonEppSdkTests/FundsTransferNotificationsTests.cs
@@ -16,6 +16,7 @@ namespace PelotonEppSdkTests
         {
             var factory = new RequestFactory(24, "Password123", "PelonEppSdkTests", baseUri);
             var transferNotificationsToken = factory.GetFundsTransferNotificationsTokenRequest();
+            transferNotificationsToken.AccountToken = "0C01957EE5D8B468342E673CC010BE0A";
             transferNotificationsToken.FromDateUtc = DateTime.UtcNow.ToString("yyyy-MM-dd");
             return transferNotificationsToken;
         }
@@ -24,6 +25,7 @@ namespace PelotonEppSdkTests
         {
             var factory = new RequestFactory(24, "Password123", "PelonEppSdkTests", baseUri);
             var transferNotifications = factory.GetFundsTransferNotificationsRequest();
+            transferNotifications.AccountToken = "0C01957EE5D8B468342E673CC010BE0A";
             transferNotifications.Token = token;
             transferNotifications.Items = items;
             return transferNotifications;


### PR DESCRIPTION
In this change set, support has been added for the optional AccountToken (account_token) fields that were recently introduced to the API for the following endponts:
- /v1/CreditCards (needed when verifying a card)
- /v1/CreditCardTransactions
- /v1/FundsTransferNotifications

The Account Token field is required when there is more than one Account available.