### PR TITLE
Fix the phone number and email address fields for `CreditCardTransactionRequest`

### DIFF
--- a/PelotonEppSdk/Interfaces/ICreditCardCreateRequest.cs
+++ b/PelotonEppSdk/Interfaces/ICreditCardCreateRequest.cs
@@ -4,7 +4,7 @@ using PelotonEppSdk.Models;
 
 namespace PelotonEppSdk.Interfaces
 {
-    public interface ICreditCardCreateRequest
+    public interface ICreditCardCreateRequest : IOptionalAccountToken
     {
         string OrderNumber { get; set; }
         string CardOwner { get; set; }

--- a/PelotonEppSdk/Models/CreditCardTransactionRequest.cs
+++ b/PelotonEppSdk/Models/CreditCardTransactionRequest.cs
@@ -157,17 +157,17 @@ namespace PelotonEppSdk.Models
 
         public string billing_name { get; set; }
 
-        public string billing_email { get; set; }
+        public string billing_email_address { get; set; }
 
-        public string billing_phone { get; set; }
+        public string billing_phone_number { get; set; }
 
         public address billing_address { get; set; }
 
         public string shipping_name { get; set; }
 
-        public string shipping_email { get; set; }
+        public string shipping_email_address { get; set; }
 
-        public string shipping_phone { get; set; }
+        public string shipping_phone_number { get; set; }
 
         public address shipping_address { get; set; }
 
@@ -191,13 +191,13 @@ namespace PelotonEppSdk.Models
                 amount = creditCardTransactionRequest.Amount,
                 type = creditCardTransactionRequest.Type,
                 billing_name = creditCardTransactionRequest.BillingName,
-                billing_email = creditCardTransactionRequest.BillingEmail,
-                billing_phone = creditCardTransactionRequest.BillingPhone,
+                billing_email_address = creditCardTransactionRequest.BillingEmail,
+                billing_phone_number = creditCardTransactionRequest.BillingPhone,
                 billing_address = (address)creditCardTransactionRequest.BillingAddress,
 
                 shipping_name = creditCardTransactionRequest.ShippingName,
-                shipping_email = creditCardTransactionRequest.ShippingEmail,
-                shipping_phone = creditCardTransactionRequest.ShippingPhone,
+                shipping_email_address = creditCardTransactionRequest.ShippingEmail,
+                shipping_phone_number = creditCardTransactionRequest.ShippingPhone,
                 shipping_address = (address)creditCardTransactionRequest.ShippingAddress,
 
                 transaction_ref_code = creditCardTransactionRequest.TransactionRefCode,

--- a/PelotonEppSdkTests/CreditCardCreateTests.cs
+++ b/PelotonEppSdkTests/CreditCardCreateTests.cs
@@ -85,6 +85,8 @@ namespace PelotonEppSdkTests
             //var factory = new RequestFactory(80, "e9ab9532", "PelonEppSdkTests");
             var createRequest = factory.GetCreditCardCreateRequest();
 
+            createRequest.AccountToken = "1D4E237930EB70FC115E6ACD95E878E6";
+
             createRequest.OrderNumber = Guid.NewGuid().ToString().Replace("-","").Substring(0,9);
             createRequest.BillingName = "P. Tech.";
             createRequest.BillingEmail = "p.tech@peloton-technologies.com";

--- a/PelotonEppSdkTests/CreditCardTransactionRequestTests.cs
+++ b/PelotonEppSdkTests/CreditCardTransactionRequestTests.cs
@@ -161,6 +161,8 @@ namespace PelotonEppSdkTests
             var factory = new RequestFactory(107, "9cf9b8f4", "PelonEppSdkTests", baseUri);
             var request = factory.GetUntokenizedCreditCardTransactionRequest();
 
+            request.AccountToken = "1D4E237930EB70FC115E6ACD95E878E6";
+
             request.CardOwner        = "P. Tech.";
             request.CardNumber       = 5499990123456781;
             request.ExpiryMonth      = "12";

--- a/PelotonEppSdkTests/CreditCardTransactionTokenRequestTests.cs
+++ b/PelotonEppSdkTests/CreditCardTransactionTokenRequestTests.cs
@@ -163,6 +163,8 @@ namespace PelotonEppSdkTests
             var factory = new RequestFactory(107, "9cf9b8f4", "PelonEppSdkTests", baseUri);
             var request = factory.GetCreditCardTransactionRequest();
 
+            request.AccountToken = "1D4E237930EB70FC115E6ACD95E878E6";
+
             request.OrderNumber = "12345678";
             request.CreditCardToken = "70401f6f4f684ab4a24728181f368d7c"; //"2fb92b4fb43a453288b388fcce6659d3"; //  "93610b81fd4749f69b81d7f12286bf61"; //"3aa58fecce92433fbcc17ea9a3e6d923"; // "ae7b55027a6a439ea29a1e2b718e0f8a";// "6fefd54fa8854710a8331797bfd14e3a";
             request.Amount = (decimal?) 1.00;


### PR DESCRIPTION
Fix the phone number and email address fields for `CreditCardTransactionRequest`.
Fix an issue where the AccountToken property was not correctly available in certain cases.
Also update some tests to use a specific account token.